### PR TITLE
Allow injection of Configuration objects into Engine

### DIFF
--- a/ingestclient/client.py
+++ b/ingestclient/client.py
@@ -93,7 +93,7 @@ def worker_process_run(config_file, api_token, job_id, pipe):
     always_log_info("  - Process pid={} finished gracefully.".format(os.getpid()))
     
 
-def main():
+def get_parser():
     parser = argparse.ArgumentParser(description="Client for facilitating large-scale data ingest",
                                      formatter_class=argparse.RawDescriptionHelpFormatter,
                                      epilog="Visit https://docs.theBoss.io for more details")
@@ -127,6 +127,10 @@ def main():
                         help="The number of client processes that will upload the images of the ingest job.")
     parser.add_argument("config_file", nargs='?', help="Path to the ingest job configuration file")
 
+    return parser
+
+def main():
+    parser = get_parser()
     args = parser.parse_args()
 
     # Get the version

--- a/ingestclient/core/engine.py
+++ b/ingestclient/core/engine.py
@@ -25,7 +25,7 @@ from collections import deque
 
 
 class Engine(object):
-    def __init__(self, config_file=None, backend_api_token=None, ingest_job_id=None):
+    def __init__(self, config_file=None, backend_api_token=None, ingest_job_id=None, configuration=None):
         """
         A class to implement the core upload client workflow engine
 
@@ -53,10 +53,12 @@ class Engine(object):
         self.job_params = None
         self.tile_count = 0
 
-        if config_file:
-            self.load_configuration(config_file)
+        if configuration:
+            self.configure(configuration)
+        elif config_file:
+            self.configure_from_file(config_file)
 
-    def load_configuration(self, config_file):
+    def configure_from_file(self, config_file):
         """
         Method to load a configuration file and setup the workflow engine
         Args:
@@ -81,8 +83,20 @@ class Engine(object):
             raise ConfigFileError(
                 "Ingest Configuration File not found.  Double check the provided path: {}".format(config_file))
 
+        self.configure(Configuration(config_data))
+
+    def configure(self, configuration):
+        """
+        Method to apply a configuration and setup the workflow engine
+        Args:
+            configuration (Configuration)
+
+        Returns:
+            None
+        """
+
         # Load Config file and validate
-        self.config = Configuration(config_data)
+        self.config = configuration
         self.config.load_plugins()
 
         # Get backend

--- a/ingestclient/plugins/stack.py
+++ b/ingestclient/plugins/stack.py
@@ -151,7 +151,24 @@ class ZindexStackTileProcessor(TileProcessor):
         tile_data = Image.open(file_handle)
         upload_img = tile_data.crop((x_range[0], y_range[0], x_range[1], y_range[1]))
         output = six.BytesIO()
-        upload_img.save(output, format=self.parameters["extension"].upper())
+        upload_img.save(output, format=canonical_extension(self.parameters["extension"]))
 
         # Send handle back
         return output
+
+EXTENSIONS =  {
+    'TIFF': ['TIF', 'TIFF'],
+    'JPG' : ['JPG', 'JPEG']
+}
+
+def canonical_extension(extension):
+    '''
+    Given an alternatively spelled extension (e.g. tif), return the canonical form (e.g. TIFF)
+    Must be one of the values in Image.SAVE.
+    see: http://pillow.readthedocs.io/en/3.1.x/handbook/image-file-formats.html
+    '''
+    for (key, spellings) in EXTENSIONS.items():
+        if extension.upper() in spellings:
+            return key
+    return extension.upper()
+    

--- a/ingestclient/utils/console.py
+++ b/ingestclient/utils/console.py
@@ -4,18 +4,24 @@ from .log import always_log_info
 import pprint
 
 
-def print_estimated_job(config_file):
+def print_estimated_job(config_file=None, configuration=None):
     """Method to print details about the job the user is about to start
 
-    Args:
+    Kwd Args:
         config_file(str): Path to the config file
+        configuration(Configuration): Configuration object
 
     Returns:
         None
     """
-    # Load file
-    with open(config_file, 'rt') as cf:
-        config = json.load(cf)
+    if config_file is not None:
+        # Load file
+        with open(config_file, 'rt') as cf:
+            config = json.load(cf)
+    elif configuration is not None:
+        config = configuration.config_data
+    else:
+        raise Exception('Must provide either a configuration object or a filename referencing one')
 
     # Compute number of tiles
     num_tiles = (config["ingest_job"]["extent"]["x"][1] * config["ingest_job"]["extent"]["y"][1]) / (config["ingest_job"]["tile_size"]["x"] * config["ingest_job"]["tile_size"]["y"])


### PR DESCRIPTION
Proposed patch for [issue: Engine should take a config object](https://github.com/jhuapl-boss/ingest-client/issues/4)

This patch allows you to directly pass a `Configuration` object to `ingestclient.client`, rather than a filename. This allows you to invoke the client programmatically.

The `argparse` object is also injectable, in case you want to programmatically change any of the other arguments, such as `force`. Here is an example of use:

```
import os
import json
from ingestclient.client import main, get_parser
from ingestclient.core.config import Configuration

DIR = os.path.dirname(__file__)
FILENAME = 'test_way3.json'

def get_path(filename):
    return os.path.abspath(os.path.join(DIR, 'data', 'Waypoint1.3a', filename))

if __name__ == '__main__':
    data = json.load(open(get_path(FILENAME)))
    configuration = Configuration(data)
    args = get_parser().parse_args([])
    args.force = True
    main(configuration=configuration, parser_args=args)
```

Testing: invoked ingest with both above snippet and with regular command-line invocation.