### PR TITLE
moved try catch to top of Engine.run() loop

### DIFF
--- a/ingestclient/core/engine.py
+++ b/ingestclient/core/engine.py
@@ -277,45 +277,46 @@ class Engine(object):
         # Do some work
         wait_cnt = 0
         while True:
-            # Check if you need to renew credentials
-            if (datetime.datetime.now() - self.credential_create_time).total_seconds() > self.backend.credential_timeout:
-                logger.warning("(pid={}) Credentials are expiring soon, attempting to renew credentials".format(os.getpid()))
-                self.join()
-                always_log_info("(pid={}) Credentials refreshed successfully".format(os.getpid()))
-
-            # Get a task
-            message_id, receipt_handle, msg = self.backend.get_task()
-
-            if not msg:
-                time.sleep(10)
-                wait_cnt += 1
-                if wait_cnt < self.msg_wait_iterations:
-                    continue
-                else:
-                    break
-
-            wait_cnt = 0
-            key_parts = self.backend.decode_tile_key(msg['tile_key'])
-            logger.info("(pid={}) Processing Task -  X:{} Y:{} Z:{} T:{}".format(os.getpid(),
-                                                                                 key_parts["x_index"],
-                                                                                 key_parts["y_index"],
-                                                                                 key_parts["z_index"],
-                                                                                 key_parts["t_index"]))
-
-            # Call path processor
-            filename = self.path_processor.process(key_parts["x_index"],
-                                                   key_parts["y_index"],
-                                                   key_parts["z_index"],
-                                                   key_parts["t_index"])
-
-            # Call tile processor
-            handle = self.tile_processor.process(filename,
-                                                 key_parts["x_index"],
-                                                 key_parts["y_index"],
-                                                 key_parts["z_index"],
-                                                 key_parts["t_index"])
-
             try:
+                # Check if you need to renew credentials
+                if (datetime.datetime.now() - self.credential_create_time).total_seconds() > self.backend.credential_timeout:
+                    logger.warning("(pid={}) Credentials are expiring soon, attempting to renew credentials".format(os.getpid()))
+                    self.join()
+                    always_log_info("(pid={}) Credentials refreshed successfully".format(os.getpid()))
+
+                # Get a task
+                message_id, receipt_handle, msg = self.backend.get_task()
+
+                if not msg:
+                    time.sleep(10)
+                    wait_cnt += 1
+                    if wait_cnt < self.msg_wait_iterations:
+                        continue
+                    else:
+                        break
+
+                wait_cnt = 0
+
+                key_parts = self.backend.decode_tile_key(msg['tile_key'])
+                logger.info("(pid={}) Processing Task -  X:{} Y:{} Z:{} T:{}".format(os.getpid(),
+                                                                                     key_parts["x_index"],
+                                                                                     key_parts["y_index"],
+                                                                                     key_parts["z_index"],
+                                                                                     key_parts["t_index"]))
+
+                # Call path processor
+                filename = self.path_processor.process(key_parts["x_index"],
+                                                       key_parts["y_index"],
+                                                       key_parts["z_index"],
+                                                       key_parts["t_index"])
+
+                # Call tile processor
+                handle = self.tile_processor.process(filename,
+                                                     key_parts["x_index"],
+                                                     key_parts["y_index"],
+                                                     key_parts["z_index"],
+                                                     key_parts["t_index"])
+
                 metadata = {'chunk_key': msg['chunk_key'],
                             'ingest_job': self.ingest_job_id,
                             'parameters': self.job_params,


### PR DESCRIPTION
The try-catch in Engine.run() was just around the ingest client’s IO to S3, but user developed plugins can be doing IO to anything and have random, transient errors as well. Simply moved the try statement to the top of the loop.