### PR TITLE
Tile Sizes added to S3 Put MetaData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Boss Ingest Client Changelog
 
+## 0.9.10
+
+### Fixed Bug:
+
+* Added x and y tile sizes to metadata of s3 tiles.  This allows the ingest backend to create blank tiles when corrupt images are received. 
+
+
 ## 0.9.9
 
 ### Fixed Bug:

--- a/debug.py
+++ b/debug.py
@@ -47,7 +47,7 @@ def main():
                                      epilog="Visit https://docs.theBoss.io for more details")
 
     parser.add_argument("queue_name",
-                        help="Name of the ingest SQS queue")
+                        help="URL of the ingest SQS queue")
 
     parser.add_argument("data_dir",
                         default=None,

--- a/ingestclient/__init__.py
+++ b/ingestclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.9'
+__version__ = '0.9.10'
 
 
 def check_version():

--- a/ingestclient/core/engine.py
+++ b/ingestclient/core/engine.py
@@ -340,8 +340,6 @@ class Engine(object):
                                                  key_parts["t_index"])
 
             try:
-                print("x_tile_size: " + str(self.config.config_data['ingest_job']["tile_size"]["x"]))
-                print("x_tile_size: " + str(self.config.config_data['ingest_job']["tile_size"]["x"]))
                 metadata = {'chunk_key': msg['chunk_key'],
                             'ingest_job': self.ingest_job_id,
                             'parameters': self.job_params,

--- a/ingestclient/core/engine.py
+++ b/ingestclient/core/engine.py
@@ -23,7 +23,6 @@ import random
 from .config import Configuration, ConfigFileError
 from collections import deque
 
-
 class Engine(object):
     def __init__(self, config_file=None, backend_api_token=None, ingest_job_id=None, configuration=None):
         """
@@ -341,9 +340,13 @@ class Engine(object):
                                                  key_parts["t_index"])
 
             try:
+                print("x_tile_size: " + str(self.config.config_data['ingest_job']["tile_size"]["x"]))
+                print("x_tile_size: " + str(self.config.config_data['ingest_job']["tile_size"]["x"]))
                 metadata = {'chunk_key': msg['chunk_key'],
                             'ingest_job': self.ingest_job_id,
                             'parameters': self.job_params,
+                            'x_size': self.config.config_data['ingest_job']["tile_size"]["x"],
+                            'y_size': self.config.config_data['ingest_job']["tile_size"]["y"],
                             }
                 handle.seek(0)
                 response = self.backend.bucket.put_object(ACL='private',


### PR DESCRIPTION
These changes are  needed to allow ingest_lambda correctly handle corrupt tiles.  With out them it does not know how to shape the ndarray given a corrupt tile.

added x_tile and y_tile to engine.py s3 put metadata, which is needed by the ingest_lambda on the backend to handle corrupt tiles.

Fixed a misleading argument tag in debug.py
Updated version and change log to reflect the changes