### PR TITLE
Updated intern.py plugin to use no_cache option when getting a cutout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Boss Ingest Client Changelog
 
+## 0.9.11
+
+### Implemented Enhancements:
+
+* Added no_cache option to the intern plugin, this will increase the download speed be avoiding the cache.
+
+
 ## 0.9.10
 
 ### Fixed Bug:

--- a/ingestclient/__init__.py
+++ b/ingestclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.10'
+__version__ = '0.9.11'
 
 
 def check_version():

--- a/ingestclient/plugins/intern.py
+++ b/ingestclient/plugins/intern.py
@@ -125,7 +125,8 @@ class InternTileProcessor(TileProcessor):
             cnt = 0
             while cnt < 5:
                 try:
-                    data = self.remote.get_cutout(self.channel, self.parameters["resolution"], x_rng, y_rng, z_rng)
+                    data = self.remote.get_cutout(self.channel, self.parameters["resolution"],
+                                                  x_rng, y_rng, z_rng, no_cache=True)
                     data = np.asarray(data, np.uint32)
                     break
                 except Exception as err:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ moto==0.4.25
 Pillow>=3.3.1
 numpy>=1.11.1
 nose2>=0.6.5
-intern>=0.9.6
+intern>=0.9.7
 


### PR DESCRIPTION
Adding no_cache option to intern plugin to avoid the cache.  Also changed Version and Changelog.