### PR TITLE
Now check that current-tiles are zero before making job as complete, …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Boss Ingest Client Changelog
 
+## 0.9.11
+
+### Implemented Enhancements:
+
+* Added no_cache option to the intern plugin, this will increase the download speed be avoiding the cache.
+
+
 ## 0.9.10
 
 ### Fixed Bug:

--- a/ingestclient/__init__.py
+++ b/ingestclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.9.10'
+__version__ = '0.9.11'
 
 
 def check_version():

--- a/ingestclient/client.py
+++ b/ingestclient/client.py
@@ -199,6 +199,8 @@ def upload(engine, args, configuration, start_time):
             if status:
                 if status["current_message_count"] == 0:
                     job_complete = True
+                else:
+                    always_log_info("Error: Something has gone wrong, monitor has ended even though there are still messages in upload queue.")
             else:
                 always_log_info("Unable to get job status - not marking job as complete.")
 

--- a/ingestclient/client.py
+++ b/ingestclient/client.py
@@ -195,7 +195,13 @@ def upload(engine, args, configuration, start_time):
             engine.monitor(workers)
             # run will end if no more jobs are available, join other processes
             should_run = False
-            job_complete = True
+            status = engine.backend.get_job_status(engine.ingest_job_id)
+            if status:
+                if status["current_message_count"] == 0:
+                    job_complete = True
+            else:
+                always_log_info("Unable to get job status - not marking job as complete.")
+
         except KeyboardInterrupt:
             # Make sure they want to stop this client
             while True:

--- a/ingestclient/core/engine.py
+++ b/ingestclient/core/engine.py
@@ -242,7 +242,7 @@ class Engine(object):
                 else:
                     log_str = "Uploading in progress: Elapsed time {:.2f} minutes"
                     log_str = log_str.format((time.time() - start_time) / 60)
-                    always_log_info()
+                    always_log_info(log_str)
 
             # Wait to loop
             time.sleep(10)

--- a/ingestclient/plugins/intern.py
+++ b/ingestclient/plugins/intern.py
@@ -125,7 +125,8 @@ class InternTileProcessor(TileProcessor):
             cnt = 0
             while cnt < 5:
                 try:
-                    data = self.remote.get_cutout(self.channel, self.parameters["resolution"], x_rng, y_rng, z_rng)
+                    data = self.remote.get_cutout(self.channel, self.parameters["resolution"],
+                                                  x_rng, y_rng, z_rng, no_cache=True)
                     data = np.asarray(data, np.uint32)
                     break
                 except Exception as err:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ moto==0.4.25
 Pillow>=3.3.1
 numpy>=1.11.1
 nose2>=0.6.5
-intern>=0.9.6
+intern>=0.9.7
 


### PR DESCRIPTION
I meant to add this to a new branch but messed up.  PR will still work fine.  I am not checking for current-tiles = zero before marking job as complete.
Also realized that the engine always_log_info() was not passing in the variable to be logged.