### PR TITLE
Smaller metadata - to master

### DIFF
--- a/ingestclient/core/engine.py
+++ b/ingestclient/core/engine.py
@@ -22,7 +22,6 @@ from math import floor
 import random
 from .config import Configuration, ConfigFileError
 from collections import deque
-from pprint import pprint
 
 class Engine(object):
     def __init__(self, config_file=None, backend_api_token=None, ingest_job_id=None, configuration=None):


### PR DESCRIPTION
Ingest-jobs on integration stack hit the 2K metadata limit on user-defined metadata.  The PR eliminates values of some metadata dictionary keys.  The keys are left as SPDB will not load correctly without them. 