### PR TITLE
Volumetric ingest - CloudVolume support

### DIFF
--- a/ingestclient/configs/boss-v0.2-cloudvolume-example.json
+++ b/ingestclient/configs/boss-v0.2-cloudvolume-example.json
@@ -1,0 +1,48 @@
+{
+  "schema": {
+      "name": "boss-v0.2-schema",
+      "validator": "BossValidatorV02"
+  },
+  "client": {
+    "backend": {
+      "name": "boss",
+      "class": "BossBackend",
+      "host": "api.theboss.io",
+      "protocol": "https"
+    },
+    "path_processor": {
+      "class": "ingestclient.plugins.cloudvolume.CloudVolumePathProcessor",
+      "params": {
+      }
+    },
+    "chunk_processor": {
+      "class": "ingestclient.plugins.cloudvolume.CloudVolumeChunkProcessor",
+      "params": {
+        "cloudpath": "gs://neuroglancer/foo/bar"
+      }
+    }
+  },
+  "database": {
+    "collection": "my_col_1",
+    "experiment": "my_exp_1",
+    "channel": "my_ch_1"
+  },
+  "ingest_job": {
+    "ingest_type": "volumetric",
+    "resolution": 0,
+    "extent": {
+      "x": [0, 8192],
+      "y": [0, 8192],
+      "z": [0, 500],
+      "t": [0, 1]
+    },
+    "chunk_size": {
+      "x": 1024,
+      "y": 1024,
+      "z": 64
+    }
+  }
+}
+
+
+

--- a/ingestclient/core/backend.py
+++ b/ingestclient/core/backend.py
@@ -426,7 +426,8 @@ class BossBackend(Backend):
 
                     self.setup_upload_queue(creds, queue, region="us-east-1")
                     self.setup_tile_bucket(creds, tile_bucket, region="us-east-1")
-                    self.setup_volumetric_bucket(creds, result["ingest_bucket_name"], region="us-east-1")
+                    if "ingest_bucket_name" in result:
+                        self.setup_volumetric_bucket(creds, result["ingest_bucket_name"], region="us-east-1")
 
                     return job_status, creds, queue, tile_bucket, params, num_tiles
 

--- a/ingestclient/core/config.py
+++ b/ingestclient/core/config.py
@@ -391,15 +391,32 @@ class Configuration(object):
             None
         """
         # Create plugin instances
-        package, class_name = self.config_data["client"]["tile_processor"]["class"].rsplit('.', 1)
-        tile_module = importlib.import_module(package)
-        tile_class = getattr(tile_module, class_name)
-        self.tile_processor_class = tile_class()
+        if "tile_processor" in self.config_data["client"]:
+            package, class_name = self.config_data["client"]["tile_processor"]["class"].rsplit('.', 1)
+            tile_module = importlib.import_module(package)
+            tile_class = getattr(tile_module, class_name)
+            self.tile_processor_class = tile_class()
+
+        if "chunk_processor" in self.config_data["client"]:
+            package, class_name = self.config_data["client"]["chunk_processor"]["class"].rsplit('.', 1)
+            chunk_module = importlib.import_module(package)
+            chunk_class = getattr(chunk_module, class_name)
+            self.chunk_processor_class = chunk_class()
 
         package, class_name = self.config_data["client"]["path_processor"]["class"].rsplit('.', 1)
         path_module = importlib.import_module(package)
         path_class = getattr(path_module, class_name)
         self.path_processor_class = path_class()
+
+    def get_chunk_processor_params(self):
+        """Method to get the chunk processor parameter dictionary
+
+        Returns:
+            (dict): Dictionary of params from the config file
+        """
+        params = self.config_data["client"]["chunk_processor"]["params"]
+        params["ingest_job"] = self.config_data["ingest_job"]
+        return params
 
     def get_tile_processor_params(self):
         """Method to get the tile processor parameter dictionary

--- a/ingestclient/core/consts.py
+++ b/ingestclient/core/consts.py
@@ -1,0 +1,18 @@
+# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The Boss cuboid dimensions (taken from spdb).
+BOSS_CUBOID_X = 512
+BOSS_CUBOID_Y = 512
+BOSS_CUBOID_Z = 16

--- a/ingestclient/core/engine.py
+++ b/ingestclient/core/engine.py
@@ -22,6 +22,11 @@ from math import floor
 import random
 from .config import Configuration, ConfigFileError
 from collections import deque
+import blosc
+import numpy as np
+from .consts import BOSS_CUBOID_X, BOSS_CUBOID_Y, BOSS_CUBOID_Z 
+from ..plugins.chunk import XYZ_ORDER, ZYX_ORDER, XYZT_ORDER, TZYX_ORDER
+
 
 class Engine(object):
     def __init__(self, config_file=None, backend_api_token=None, ingest_job_id=None, configuration=None):
@@ -38,16 +43,26 @@ class Engine(object):
         self.msg_wait_iterations = 20  # Each iteration waits for 10 seconds for incoming messages
         self.backend = None
         self.validator = None
+        self.chunk_processor = None
         self.tile_processor = None
         self.path_processor = None
         self.backend_api_token = backend_api_token
         self.credential_create_time = None
+        self.logger = logging.getLogger('ingest-client')
+
+        # Number of cuboids in a chunk for volumetric ingest.  This will be
+        # updated from the ingest config.
+        self.num_x_cuboids = 1
+        self.num_y_cuboids = 1
+        self.num_z_cuboids = 1
 
         # Properties of ingest after creation
         self.credentials = None
         self.ingest_job_id = ingest_job_id
         self.upload_job_queue = None
         self.job_status = 0
+        # When running a volumetric ingest, tile_bucket points to a bucket for
+        # cuboids.
         self.tile_bucket = None
         self.job_params = None
         self.tile_count = 0
@@ -110,8 +125,19 @@ class Engine(object):
         self.validator.schema = self.config.schema
 
         # Setup tile processor
-        self.tile_processor = self.config.tile_processor_class
-        self.tile_processor.setup(self.config.get_tile_processor_params())
+        if ("ingest_type" not in self.config.config_data["ingest_job"] or
+                self.config.config_data["ingest_job"]["ingest_type"] == "tile"):
+            self.tile_processor = self.config.tile_processor_class
+            self.tile_processor.setup(self.config.get_tile_processor_params())
+
+        # Setup chunk processor
+        if ("ingest_type" in self.config.config_data["ingest_job"] and
+                self.config.config_data["ingest_job"]["ingest_type"] == "volumetric"):
+            self.chunk_processor = self.config.chunk_processor_class
+            self.chunk_processor.setup(self.config.get_chunk_processor_params())
+            self.num_x_cuboids = self.config.config_data["ingest_job"]["chunk_size"]["x"] // BOSS_CUBOID_X
+            self.num_y_cuboids = self.config.config_data["ingest_job"]["chunk_size"]["y"] // BOSS_CUBOID_Y
+            self.num_z_cuboids = self.config.config_data["ingest_job"]["chunk_size"]["z"] // BOSS_CUBOID_Z
 
         # Setup path processor
         self.path_processor = self.config.path_processor_class
@@ -119,16 +145,14 @@ class Engine(object):
 
     def setup(self):
         """Method to setup the Engine by finishing configuring subclasses and validating the schema"""
-        logger = logging.getLogger('ingest-client')
-
         msgs = self.validator.validate()
 
         for msg in msgs["info"]:
-            logger.info(msg)
+            self.logger.info(msg)
 
         if msgs["error"]:
             for msg in msgs["error"]:
-                logger.info(msg)
+                self.logger.info(msg)
             raise Exception("Validation Failed: {}".format(" - ".join(msgs["error"])))
 
         return msgs["question"]
@@ -200,7 +224,6 @@ class Engine(object):
         Returns:
             None
         """
-        logger = logging.getLogger('ingest-client')
         tile_rate_samples = deque(maxlen=6)
         last_task_count = None
         start_time = time.time()
@@ -209,7 +232,7 @@ class Engine(object):
         while True:
             total_seconds = (datetime.datetime.now() - self.credential_create_time).total_seconds()
             if total_seconds > self.backend.credential_timeout:
-                logger.warning("(pid={}) Credentials are expiring soon, attempting to renew credentials".format(
+                self.logger.warning("(pid={}) Credentials are expiring soon, attempting to renew credentials".format(
                     os.getpid()))
                 self.join()
                 always_log_info("(pid={}) Credentials refreshed successfully".format(os.getpid()))
@@ -263,23 +286,20 @@ class Engine(object):
         Returns:
 
         """
-        # Set up logger
-        logger = logging.getLogger('ingest-client')
-
         # Make sure you are joined
         if not self.credentials:
             msg = "(pid={}) Cannot start ingest engine.  Credentials not successfully received from the ingest service.".format(os.getpid())
-            logger.error(msg)
+            self.logger.error(msg)
             raise Exception(msg)
 
         if self.job_status == 0:
             msg = "(pid={}) Cannot start ingest engine.  Ingest job is not ready yet.".format(os.getpid())
-            logger.error(msg)
+            self.logger.error(msg)
             raise Exception(msg)
 
         if self.job_status == 2:
             msg = "(pid={}) Ingest job already completed. Skipping ingest engine start.".format(os.getpid())
-            logger.warning(msg)
+            self.logger.warning(msg)
             raise Exception(msg)
 
         # Do some work
@@ -302,7 +322,7 @@ class Engine(object):
             # Check if you need to renew credentials
             total_seconds = (datetime.datetime.now() - self.credential_create_time).total_seconds()
             if total_seconds > self.backend.credential_timeout:
-                logger.warning("(pid={}) Credentials are expiring soon, attempting to renew credentials".format(
+                self.logger.warning("(pid={}) Credentials are expiring soon, attempting to renew credentials".format(
                     os.getpid()))
                 self.join()
                 always_log_info("(pid={}) Credentials refreshed successfully".format(os.getpid()))
@@ -319,64 +339,216 @@ class Engine(object):
                     break
 
             wait_cnt = 0
-            key_parts = self.backend.decode_tile_key(msg['tile_key'])
-            logger.info("(pid={}) Processing Task -  X:{} Y:{} Z:{} T:{}".format(os.getpid(),
-                                                                                 key_parts["x_index"],
-                                                                                 key_parts["y_index"],
-                                                                                 key_parts["z_index"],
-                                                                                 key_parts["t_index"]))
 
-            # Call path processor
-            filename = self.path_processor.process(key_parts["x_index"],
-                                                   key_parts["y_index"],
-                                                   key_parts["z_index"],
-                                                   key_parts["t_index"])
+            if ("ingest_type" not in self.config.config_data["ingest_job"] or
+                    self.config.config_data["ingest_job"]["ingest_type"] == "tile"):
+                if not self.upload_tile(msg, message_id, receipt_handle):
+                    break
+            elif self.config.config_data["ingest_job"]["ingest_type"] == "volumetric":
+                if not self.upload_chunk(msg, message_id, receipt_handle):
+                    break
+            else:
+                self.logger.error("Invalid ingest_type specified: {}".format(self.config.config_data["ingest_job"]["ingest_type"]))
+                return
 
-            # Call tile processor
-            handle = self.tile_processor.process(filename,
-                                                 key_parts["x_index"],
-                                                 key_parts["y_index"],
-                                                 key_parts["z_index"],
-                                                 key_parts["t_index"])
+    def upload_tile(self, msg, message_id, receipt_handle):
+        """Upload a single tile
 
-            try:
-                metadata = {'chunk_key': msg['chunk_key'],
-                            'ingest_job': self.ingest_job_id,
-                            'parameters': self.job_params,
-                            'x_size': self.config.config_data['ingest_job']["tile_size"]["x"],
-                            'y_size': self.config.config_data['ingest_job']["tile_size"]["y"],
-                            }
-                handle.seek(0)
-                response = self.backend.bucket.put_object(ACL='private',
-                                                          Body=handle,
-                                                          Key=msg['tile_key'],
-                                                          Metadata={
-                                                              'message_id': message_id,
-                                                              'receipt_handle': receipt_handle,
-                                                              'metadata': json.dumps(metadata, separators=(',', ':'))
-                                                          },
-                                                          StorageClass='STANDARD')
-                logger.info("(pid={}) Successfully wrote file: {}".format(os.getpid(), response.key))
+        Args:
+            msg (dict): Message contents from upload queue
+            message_id (str):
+            receipt_handle (str): Necessary to remove the message from the upload queue
 
-            except Exception as e:
-                logger.error("(pid={}) Upload Failed -  X:{} Y:{} Z:{} T:{} - {}".format(os.getpid(),
-                                                                                         key_parts["x_index"],
-                                                                                         key_parts["y_index"],
-                                                                                         key_parts["z_index"],
-                                                                                         key_parts["t_index"],
-                                                                                         e))
-                if str(e).startswith("An error occurred (AccessDenied) when calling the PutObject operation"):
-                    self.access_denied = True
-                    self.access_denied_count += 1
-                    if self.access_denied_count >= 20:
-                        logger.error("(pid={}) failed 20 times with same error, breaking out of loop: {} ".format(
-                            os.getpid(), e))
-                        break
-                elif str(e).startswith("An error occurred (InvalidAccessKeyId) when calling the PutObject operation"):
-                    time.sleep(5)
-                    self.invalid_access_key = True
-                    self.invalid_access_key_count += 1
-                    if self.invalid_access_key_count >= 20:
-                        logger.error("(pid={}) failed 20 times with same error, breaking out of loop: {} ".format(
-                            os.getpid(), e))
-                        break
+        Returns:
+            (bool): False if upload should be aborted.
+        """
+        key_parts = self.backend.decode_tile_key(msg['tile_key'])
+        self.logger.info("(pid={}) Processing Task -  X:{} Y:{} Z:{} T:{}".format(os.getpid(),
+                                                                             key_parts["x_index"],
+                                                                             key_parts["y_index"],
+                                                                             key_parts["z_index"],
+                                                                             key_parts["t_index"]))
+
+        # Call path processor
+        filename = self.path_processor.process(key_parts["x_index"],
+                                               key_parts["y_index"],
+                                               key_parts["z_index"],
+                                               key_parts["t_index"])
+
+        # Call tile processor
+        handle = self.tile_processor.process(filename,
+                                             key_parts["x_index"],
+                                             key_parts["y_index"],
+                                             key_parts["z_index"],
+                                             key_parts["t_index"])
+
+        try:
+            metadata = {'chunk_key': msg['chunk_key'],
+                        'ingest_job': self.ingest_job_id,
+                        'parameters': self.job_params,
+                        'x_size': self.config.config_data['ingest_job']["tile_size"]["x"],
+                        'y_size': self.config.config_data['ingest_job']["tile_size"]["y"],
+                        }
+            handle.seek(0)
+            response = self.backend.bucket.put_object(ACL='private',
+                                                      Body=handle,
+                                                      Key=msg['tile_key'],
+                                                      Metadata={
+                                                          'message_id': message_id,
+                                                          'receipt_handle': receipt_handle,
+                                                          'metadata': json.dumps(metadata, separators=(',', ':'))
+                                                      },
+                                                      StorageClass='STANDARD')
+            self.logger.info("(pid={}) Successfully wrote file: {}".format(os.getpid(), response.key))
+
+        except Exception as e:
+            self.logger.error("(pid={}) Upload Tile Failed -  X:{} Y:{} Z:{} T:{} - {}".format(os.getpid(),
+                                                                                     key_parts["x_index"],
+                                                                                     key_parts["y_index"],
+                                                                                     key_parts["z_index"],
+                                                                                     key_parts["t_index"],
+                                                                                     e))
+            if str(e).startswith("An error occurred (AccessDenied) when calling the PutObject operation"):
+                self.access_denied = True
+                self.access_denied_count += 1
+                if self.access_denied_count >= 20:
+                    self.logger.error("(pid={}) failed 20 times with same error, breaking out of loop: {} ".format(
+                        os.getpid(), e))
+                    return False
+            elif str(e).startswith("An error occurred (InvalidAccessKeyId) when calling the PutObject operation"):
+                time.sleep(5)
+                self.invalid_access_key = True
+                self.invalid_access_key_count += 1
+                if self.invalid_access_key_count >= 20:
+                    self.logger.error("(pid={}) failed 20 times with same error, breaking out of loop: {} ".format(
+                        os.getpid(), e))
+                    return False
+
+        return True
+
+    def upload_chunk(self, msg, message_id, receipt_handle):
+        """Upload a single chunk as cuboids.
+
+        Args:
+            msg (dict): Message contents from upload queue
+            message_id (str):
+            receipt_handle (str): Necessary to remove the message from the upload queue
+
+        Returns:
+            (bool): False if upload should be aborted.
+        """
+        key_parts = self.backend.decode_chunk_key(msg['chunk_key'])
+        self.logger.info("(pid={}) Processing Task -  X:{} Y:{} Z:{} ".format(os.getpid(),
+                                                                         key_parts["x_index"],
+                                                                         key_parts["y_index"],
+                                                                         key_parts["z_index"]))
+
+        # Call path processor
+        filename = self.path_processor.process(key_parts["x_index"],
+                                               key_parts["y_index"],
+                                               key_parts["z_index"],
+                                               key_parts["t_index"])
+
+        # Call chunk processor
+        chunk, array_order = self.chunk_processor.process(filename,
+                                                          key_parts["x_index"],
+                                                          key_parts["y_index"],
+                                                          key_parts["z_index"])
+
+        # Make sure chunk is a C order NdArray.
+        if not chunk.flags['C_CONTIGUOUS']:
+            # Data is in a Fortran-style contiguous segment, NOT C-style so
+            # need to convert.
+            c_order_chunk = np.ascontiguousarray(chunk)
+        else:
+            c_order_chunk = chunk
+
+        # Allow for potential garbage collection if chunk was Fortan order.
+        del chunk
+
+        for cuboid_data in msg['cuboids']:
+            x = cuboid_data['x']
+            y = cuboid_data['y']
+            z = cuboid_data['z']
+            if not self.upload_cuboid(c_order_chunk, x, y, z, cuboid_data['key'], array_order):
+                return False
+
+        # Successfully uploaded all cuboids - delete message from upload queue.
+        self.backend.delete_task(message_id, receipt_handle)
+
+        return True
+
+    def upload_cuboid(self, chunk, x, y, z, key, array_order):
+        """
+        Upload a single Boss cuboid to the ingest bucket.
+
+        Args:
+            chunk (NdArray): The chunk of cuboids in C order.
+            x (int): The starting index in x of the cuboid.
+            y (int): The starting index in y of the cuboid.
+            z (int): The starting index in z of the cuboid.
+            key (str): S3 object key for storing this cuboid in the bucket.
+            array_order (int): Order of elements in array (XYZ_ORDER, TZYX_ORDER, etc).
+
+        Returns:
+            (bool): False if upload should be aborted.
+        """
+        try:
+            metadata = {
+                'ingest_job': self.ingest_job_id,
+                'parameters': self.job_params
+            }
+
+            print('chunk: {}, {}'.format(chunk.flags['C_CONTIGUOUS'], chunk.shape))
+
+            if array_order == XYZ_ORDER or array_order == XYZT_ORDER:
+                raw_sub_chunk = chunk[x:x+BOSS_CUBOID_X, y:y+BOSS_CUBOID_Y, z:z+BOSS_CUBOID_Z]
+                # Fix ordering so either Z or T first.
+                ordered_array = np.transpose(raw_sub_chunk)
+            else:
+                ordered_array = chunk[z:z+BOSS_CUBOID_Z, y:y+BOSS_CUBOID_Y, x:x+BOSS_CUBOID_X]
+
+            # Add time dimension to array.
+            if array_order == XYZ_ORDER or array_order == ZYX_ORDER:
+                array_4d = np.expand_dims(ordered_array, 0)
+            else:
+                array_4d = ordered_array
+
+            # Ensure array is in C order.
+            if not array_4d.flags['C_CONTIGUOUS']:
+                print('making c order')
+                data = np.ascontiguousarray(array_4d)
+            else:
+                data = array_4d
+
+            # Assume chunk has data type that matches the Boss channel.
+            compressed_data = blosc.compress(data, typesize=(data.dtype).itemsize * 8)
+
+            response = self.backend.bucket.put_object(ACL='private',
+                                                      Body=compressed_data,
+                                                      Key=key,
+                                                      Metadata={
+                                                          'metadata': json.dumps(metadata, separators=(',', ':'))
+                                                      },
+                                                      StorageClass='STANDARD')
+            self.logger.info("(pid={}) Successfully uploaded cuboid: {}".format(os.getpid(), response.key))
+
+        except Exception as e:
+            self.logger.error("(pid={}) Upload Cuboid Failed -  X:{} Y:{} Z:{} - {}".format(os.getpid(), x, y, z, e))
+            if str(e).startswith("An error occurred (AccessDenied) when calling the PutObject operation"):
+                self.access_denied = True
+                self.access_denied_count += 1
+                if self.access_denied_count >= 20:
+                    self.logger.error("(pid={}) failed 20 times with same error, breaking out of loop: {} ".format(
+                        os.getpid(), e))
+                    return False
+            elif str(e).startswith("An error occurred (InvalidAccessKeyId) when calling the PutObject operation"):
+                time.sleep(5)
+                self.invalid_access_key = True
+                self.invalid_access_key_count += 1
+                if self.invalid_access_key_count >= 20:
+                    self.logger.error("(pid={}) failed 20 times with same error, breaking out of loop: {} ".format(
+                        os.getpid(), e))
+                    return False
+
+        return True

--- a/ingestclient/core/engine.py
+++ b/ingestclient/core/engine.py
@@ -470,7 +470,9 @@ class Engine(object):
             x = cuboid_data['x']
             y = cuboid_data['y']
             z = cuboid_data['z']
-            if not self.upload_cuboid(c_order_chunk, x, y, z, cuboid_data['key'], array_order):
+            if not self.upload_cuboid(
+                c_order_chunk, x, y, z, cuboid_data['key'], msg['chunk_key'], array_order
+            ):
                 return False
 
         # Successfully uploaded all cuboids - delete message from upload queue.
@@ -478,7 +480,7 @@ class Engine(object):
 
         return True
 
-    def upload_cuboid(self, chunk, x, y, z, key, array_order):
+    def upload_cuboid(self, chunk, x, y, z, key, chunk_key, array_order):
         """
         Upload a single Boss cuboid to the ingest bucket.
 
@@ -488,6 +490,7 @@ class Engine(object):
             y (int): The starting index in y of the cuboid.
             z (int): The starting index in z of the cuboid.
             key (str): S3 object key for storing this cuboid in the bucket.
+            chunk_key (str): Chunk key will be stored in the S3 object's metadata.
             array_order (int): Order of elements in array (XYZ_ORDER, TZYX_ORDER, etc).
 
         Returns:
@@ -496,6 +499,7 @@ class Engine(object):
         try:
             metadata = {
                 'ingest_job': self.ingest_job_id,
+                'chunk_key': chunk_key,
                 'parameters': self.job_params
             }
 

--- a/ingestclient/core/engine.py
+++ b/ingestclient/core/engine.py
@@ -528,7 +528,7 @@ class Engine(object):
             # Assume chunk has data type that matches the Boss channel.
             compressed_data = blosc.compress(data, typesize=(data.dtype).itemsize * 8)
 
-            response = self.backend.bucket.put_object(ACL='private',
+            response = self.backend.volumetric_bucket.put_object(ACL='private',
                                                       Body=compressed_data,
                                                       Key=key,
                                                       Metadata={

--- a/ingestclient/plugins/chunk.py
+++ b/ingestclient/plugins/chunk.py
@@ -1,0 +1,63 @@
+# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import six
+from abc import ABCMeta, abstractmethod
+import numpy as np
+
+XYZ_ORDER = 0
+ZYX_ORDER = 1
+XYZT_ORDER = 2
+TZYX_ORDER = 3
+
+@six.add_metaclass(ABCMeta)
+class ChunkProcessor(object):
+    def __init__(self):
+        """
+        A class that implements a chunk processor which outputs ndarrays for uploading
+
+        Args:
+        """
+        self.parameters = None
+
+    @abstractmethod
+    def setup(self, parameters):
+        """
+        Method to initialize the chunk processor based on custom parameters from the configuration file
+
+        e.g. Connect to a database, etc.
+
+        Args:
+            parameters (dict): Parameters for the dataset to be processed
+
+        Returns:
+            None
+        """
+        return NotImplemented
+
+    @abstractmethod
+    def process(self, file_path, x_index, y_index, z_index):
+        """
+        Method to take a chunk indices and return an ndarray with the correct data
+
+        Args:
+            file_path(str): An absolute file path for the specified chunk
+            x_index(int): The tile index in the X dimension
+            y_index(int): The tile index in the Y dimension
+            z_index(int): The tile index in the Z dimension
+
+        Returns:
+            (np.ndarray, int): ndarray for the specified chunk, array order (XYZ_ORDER, TZYX_ORDER, etc)
+        """
+        return NotImplemented

--- a/ingestclient/plugins/cloudvolume.py
+++ b/ingestclient/plugins/cloudvolume.py
@@ -101,4 +101,16 @@ class CloudVolumeChunkProcessor(ChunkProcessor):
         x_size = self.ingest_job["chunk_size"]["x"]
         y_size = self.ingest_job["chunk_size"]["y"]
         z_size = self.ingest_job["chunk_size"]["z"]
-        return self.vol[x_index:x_index+x_size, y_index:y_index+y_size, z_index:z_index+z_size], XYZT_ORDER
+
+        x_stop = x_index+x_size
+        y_stop = y_index+y_size
+        z_stop = z_index+z_size
+
+        if x_stop > self.vol.bounds.maxpt[0]:
+            x_stop = self.vol.bounds.maxpt[0]
+        if y_stop > self.vol.bounds.maxpt[1]:
+            y_stop = self.vol.bounds.maxpt[1]
+        if z_stop > self.vol.bounds.maxpt[2]:
+            z_stop = self.vol.bounds.maxpt[2]
+
+        return self.vol[x_index:x_stop, y_index:y_stop, z_index:z_stop], XYZT_ORDER

--- a/ingestclient/plugins/cloudvolume.py
+++ b/ingestclient/plugins/cloudvolume.py
@@ -1,0 +1,104 @@
+# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+import six
+
+from .path import PathProcessor
+from .chunk import ChunkProcessor, XYZT_ORDER
+
+from cloudvolume import CloudVolume
+
+class CloudVolumePathProcessor(PathProcessor):
+    """Class for simple image stacks that only increment in Z, uses the dynamic filesystem utility"""
+    def __init__(self):
+        """Constructor to add custom class var"""
+        PathProcessor.__init__(self)
+
+    def setup(self, parameters):
+        """Set the params
+
+
+        Args:
+            parameters (dict): Parameters for the dataset to be processed
+
+        Returns:
+            None
+        """
+        pass
+
+    def process(self, x_index, y_index, z_index, t_index=None):
+        """
+        Method to compute the file path for the indicated tile
+
+        Args:
+            x_index(int): The tile index in the X dimension
+            y_index(int): The tile index in the Y dimension
+            z_index(int): The tile index in the Z dimension
+            t_index(int): The time index
+
+        Returns:
+            (str): An absolute file path that contains the specified data
+
+        """
+        return ""
+
+
+class CloudVolumeChunkProcessor(ChunkProcessor):
+    """Chunk processor that utilizes Seung Lab's CloudVolume"""
+
+    def __init__(self):
+        ChunkProcessor.__init__(self)
+        self.vol = None
+        self.ingest_job = None
+
+    def setup(self, parameters):
+        """ Method to load the file for uploading data. Assumes intern token is set via environment variable or config
+        default file
+
+        Args:
+            parameters (dict): Parameters for the dataset to be processed
+
+
+        MUST HAVE THE CUSTOM PARAMETER: "cloudpath": location of CloudVolume data
+
+        All other parameters are optional parameters that may be passed to the CloudVolume constructor
+
+        Returns:
+            None
+        """
+        self.parameters = parameters
+
+        # Remove 'ingest_job' key so rest of parameters can be passed to the
+        # CloudVolume constructor.
+        self.ingest_job = self.parameters.pop('ingest_job')
+        self.vol = CloudVolume(**self.parameters)
+
+    def process(self, file_path, x_index, y_index, z_index):
+        """
+        Method to take a chunk indices and return an ndarray with the correct data
+
+        Args:
+            file_path(str): An absolute file path for the specified chunk
+            x_index(int): The tile index in the X dimension
+            y_index(int): The tile index in the Y dimension
+            z_index(int): The tile index in the Z dimension
+
+        Returns:
+            (np.ndarray, int): ndarray for the specified chunk, XYZT_ORDER
+        """
+        x_size = self.ingest_job["chunk_size"]["x"]
+        y_size = self.ingest_job["chunk_size"]["y"]
+        z_size = self.ingest_job["chunk_size"]["z"]
+        return self.vol[x_index:x_index+x_size, y_index:y_index+y_size, z_index:z_index+z_size], XYZT_ORDER

--- a/ingestclient/plugins/cloudvolume.py
+++ b/ingestclient/plugins/cloudvolume.py
@@ -102,9 +102,13 @@ class CloudVolumeChunkProcessor(ChunkProcessor):
         y_size = self.ingest_job["chunk_size"]["y"]
         z_size = self.ingest_job["chunk_size"]["z"]
 
-        x_stop = x_index+x_size
-        y_stop = y_index+y_size
-        z_stop = z_index+z_size
+        x_start = x_index * x_size;
+        y_start = y_index * y_size;
+        z_start = z_index * z_size;
+
+        x_stop = x_start + x_size
+        y_stop = y_start + y_size
+        z_stop = z_start + z_size
 
         if x_stop > self.vol.bounds.maxpt[0]:
             x_stop = self.vol.bounds.maxpt[0]
@@ -113,4 +117,4 @@ class CloudVolumeChunkProcessor(ChunkProcessor):
         if z_stop > self.vol.bounds.maxpt[2]:
             z_stop = self.vol.bounds.maxpt[2]
 
-        return self.vol[x_index:x_stop, y_index:y_stop, z_index:z_stop], XYZT_ORDER
+        return self.vol[x_start:x_stop, y_start:y_stop, z_start:z_stop], XYZT_ORDER

--- a/ingestclient/plugins/requirements/cloudvolume_requirements.txt
+++ b/ingestclient/plugins/requirements/cloudvolume_requirements.txt
@@ -1,0 +1,2 @@
+numpy>=1.13.3
+cloud-volume

--- a/ingestclient/schema/boss-v0.2-schema.json
+++ b/ingestclient/schema/boss-v0.2-schema.json
@@ -1,0 +1,224 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "schema": {
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "validator": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "validator"
+      ]
+    },
+    "client": {
+      "type": "object",
+      "properties": {
+        "backend": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string"
+            },
+            "class": {
+              "type": "string"
+            },
+            "host": {
+              "type": "string"
+            },
+            "protocol": {
+              "type": "string"
+            }
+          },
+          "required": [
+            "name",
+            "class",
+            "host",
+            "protocol"
+          ]
+        },
+        "path_processor": {
+          "type": "object",
+          "properties": {
+            "class": {
+              "type": "string"
+            },
+            "params": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "required": [
+            "class",
+            "params"
+          ]
+        },
+        "tile_processor": {
+          "description": "Required if ingest_job.ingest_type == tile",
+          "type": "object",
+          "properties": {
+            "class": {
+              "type": "string"
+            },
+            "params": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "required": [
+            "class",
+            "params"
+          ]
+        },
+        "chunk_processor": {
+          "description": "Required if ingest_job.ingest_type == volumetric",
+          "type": "object",
+          "properties": {
+            "class": {
+              "type": "string"
+            },
+            "params": {
+              "type": "object",
+              "properties": {}
+            }
+          },
+          "required": [
+            "class",
+            "params"
+          ]
+        }
+      },
+      "required": [
+        "backend",
+        "path_processor"
+      ]
+    },
+    "database": {
+      "type": "object",
+      "properties": {
+        "collection": {
+          "type": "string"
+        },
+        "experiment": {
+          "type": "string"
+        },
+        "channel": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "collection",
+        "experiment",
+        "channel"
+      ]
+    },
+    "ingest_job": {
+      "type": "object",
+      "properties": {
+        "resolution": {
+          "type": "integer"
+        },
+        "ingest_type": {
+          "type": "string",
+          "enum": ["tile", "volumetric"]
+        },
+        "extent": {
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "y": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "z": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            },
+            "t": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              }
+            }
+          },
+          "required": [
+            "x",
+            "y",
+            "z",
+            "t"
+          ]
+        },
+        "tile_size": {
+          "description": "Required if ingest_type == tile",
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "integer"
+            },
+            "y": {
+              "type": "integer"
+            },
+            "z": {
+              "type": "integer"
+            },
+            "t": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "x",
+            "y",
+            "z",
+            "t"
+          ]
+        },
+        "chunk_size": {
+          "description": "Required if ingest_type == volumetric",
+          "type": "object",
+          "properties": {
+            "x": {
+              "type": "integer"
+            },
+            "y": {
+              "type": "integer"
+            },
+            "z": {
+              "type": "integer"
+            }
+          },
+          "required": [
+            "x",
+            "y",
+            "z"
+          ]
+        }
+      },
+      "required": [
+        "ingest_type",
+        "resolution",
+        "extent"
+      ]
+    }
+  },
+  "required": [
+    "schema",
+    "client",
+    "database",
+    "ingest_job"
+  ]
+}

--- a/ingestclient/test/aws.py
+++ b/ingestclient/test/aws.py
@@ -20,6 +20,8 @@ from moto import mock_sqs
 import time
 
 VOLUMETRIC_CUBOID_KEY = "md5hash&1&2&3&0&22"
+# Currently just passed to Engine.upload_cuboid() to be stored in metadata.
+VOLUMETRIC_CHUNK_KEY = "foo"
 
 
 class Setup(object):

--- a/ingestclient/test/aws.py
+++ b/ingestclient/test/aws.py
@@ -19,6 +19,8 @@ from moto import mock_sqs
 
 import time
 
+VOLUMETRIC_CUBOID_KEY = "md5hash&1&2&3&0&22"
+
 
 class Setup(object):
     """ Class to handle setting up AWS resources for testing
@@ -170,3 +172,43 @@ class Setup(object):
             mock_sqs(self._add_tasks(id, secret, queue_url, backend_instance))
         else:
             self._add_tasks(id, secret, queue_url, backend_instance)
+
+    def _add_volumetric_tasks(self, id, secret, queue_url, backend_instance):
+        """Push some fake tasks on the volumetric upload queue"""
+        client = boto3.client('sqs', region_name=self.region, aws_access_key_id=id,
+                              aws_secret_access_key=secret)
+
+        params = {
+            "cuboids": [
+                { "x": 0, "y": 0, "z": 0, "key": VOLUMETRIC_CUBOID_KEY }
+            ],
+            "collection": 1,
+            "experiment": 2,
+            "channel": 3,
+            "resolution": 0,
+            "x_index": 0,
+            "y_index": 0,
+            "z_index": 0,
+            "t_index": 0,
+            "num_tiles": 1
+        }
+
+        proj = [str(params['collection']), str(params['experiment']), str(params['channel'])]
+        chunk_key = backend_instance.encode_chunk_key(params['num_tiles'], proj,
+                                                      params['resolution'],
+                                                      params['x_index'],
+                                                      params['y_index'],
+                                                      params['z_index'],
+                                                      params['t_index'],
+                                                      )
+        self.test_msg = []
+        msg = { "chunk_key": chunk_key, "cuboids": params["cuboids"] }
+        client.send_message(QueueUrl=queue_url, MessageBody=json.dumps(msg))
+        self.test_msg.append(msg)
+
+    def add_volumetric_tasks(self, id, secret, queue_url, backend_instance):
+        """Add fake tasks to the volumetric upload queue"""
+        if self.mock:
+            mock_sqs(self._add_volumetric_tasks(id, secret, queue_url, backend_instance))
+        else:
+            self._add_volumetric_tasks(id, secret, queue_url, backend_instance)

--- a/ingestclient/test/data/boss-v0.2-cloudvolume.json
+++ b/ingestclient/test/data/boss-v0.2-cloudvolume.json
@@ -1,0 +1,46 @@
+{
+  "schema": {
+      "name": "boss-v0.2-schema",
+      "validator": "BossValidatorV02"
+  },
+  "client": {
+    "backend": {
+      "name": "boss",
+      "class": "BossBackend",
+      "host": "api.theboss.io",
+      "protocol": "https"
+    },
+    "path_processor": {
+      "class": "ingestclient.plugins.cloudvolume.CloudVolumePathProcessor",
+      "params": {
+      }
+    },
+    "chunk_processor": {
+      "class": "ingestclient.plugins.cloudvolume.CloudVolumeChunkProcessor",
+      "params": {}
+    }
+  },
+  "database": {
+    "collection": "my_col_1",
+    "experiment": "my_exp_1",
+    "channel": "my_ch_1"
+  },
+  "ingest_job": {
+    "ingest_type": "volumetric",
+    "resolution": 0,
+    "extent": {
+      "x": [0, 8192],
+      "y": [0, 8192],
+      "z": [0, 500],
+      "t": [0, 1]
+    },
+    "chunk_size": {
+      "x": 1024,
+      "y": 1024,
+      "z": 64
+    }
+  }
+}
+
+
+

--- a/ingestclient/test/data/boss-v0.2-test.json
+++ b/ingestclient/test/data/boss-v0.2-test.json
@@ -1,0 +1,63 @@
+{
+  "schema": {
+      "name": "boss-v0.2-schema",
+      "validator": "BossValidatorV02"
+  },
+  "client": {
+    "backend": {
+      "name": "boss",
+      "class": "BossBackend",
+      "host": "api.theboss.io",
+      "protocol": "https"
+    },
+    "path_processor": {
+      "class": "ingestclient.plugins.cloudvolume.CloudVolumePathProcessor",
+      "params": {
+      }
+    },
+    "chunk_processor": {
+      "class": "ingestclient.plugins.cloudvolume.CloudVolumeChunkProcessor",
+      "params": {
+        "cloudpath": "file:///tmp/cloudvolume/empty_volume",
+        "mip": 0,
+        "fill_missing": true,
+        "info": {
+          "num_channels": 1,
+          "type": "image",
+          "data_type": "uint8",
+          "scales": [{
+            "encoding": "raw",
+            "chunk_sizes": [[1024, 1024, 64]],
+            "key": "1_1_1",
+            "resolution": [1, 1, 1],
+            "voxel_offset": [0, 0, 0],
+            "size": [2048, 2048, 128]
+          }]
+        }
+      }
+    }
+  },
+  "database": {
+    "collection": "my_col_1",
+    "experiment": "my_exp_1",
+    "channel": "my_ch_1"
+  },
+  "ingest_job": {
+    "ingest_type": "volumetric",
+    "resolution": 0,
+    "extent": {
+      "x": [0, 8192],
+      "y": [0, 8192],
+      "z": [0, 500],
+      "t": [0, 1]
+    },
+    "chunk_size": {
+      "x": 1024,
+      "y": 1024,
+      "z": 64
+    }
+  }
+}
+
+
+

--- a/ingestclient/test/layer_harness.py
+++ b/ingestclient/test/layer_harness.py
@@ -1,0 +1,90 @@
+# BSD 3-Clause License
+#
+# Copyright (c) 2017, Ignacio Tartavull, William Silversmith, and later authors.
+# All rights reserved.
+
+#import pytest
+
+import shutil
+import numpy as np
+
+import os
+
+from cloudvolume import Storage, CloudVolume
+from cloudvolume.lib import Bbox, Vec, min2, max2, find_closest_divisor
+
+TEST_NUMBER = np.random.randint(0, 999999)
+CLOUD_BUCKET = 'seunglab-test'
+
+layer_path = '/tmp/removeme/'
+
+def create_storage(layer_name='layer'):
+    stor_path = os.path.join(layer_path, layer_name)
+    return Storage('file://' + stor_path, n_threads=0)
+
+def create_image(size, layer_type="image", dtype=None):
+    default = lambda dt: dtype or dt
+
+    if layer_type == "image":
+        return np.random.randint(255, size=size, dtype=default(np.uint8))
+    elif layer_type == 'affinities':
+        return np.random.uniform(low=0, high=1, size=size).astype(default(np.float32))
+    elif layer_type == "segmentation":
+        return np.random.randint(0xFFFFFF, size=size, dtype=np.uint32)
+    else:
+        high = np.array([0], dtype=default(np.uint32)) - 1
+        return np.random.randint(high[0], size=size, dtype=default(np.uint32))
+
+def create_layer(size, offset, layer_type="image", layer_name='layer', dtype=None):
+    random_data = create_image(size, layer_type, dtype)
+    vol = upload_image(random_data, offset, layer_type, layer_name)
+    return vol, random_data
+
+def upload_image(image, offset, layer_type, layer_name):
+    lpath = 'file://{}'.format(os.path.join(layer_path, layer_name))
+    
+    # Jpeg encoding is lossy so it won't work
+    vol = create_volume_from_image(
+        image, 
+        offset=offset,
+        layer_path=lpath,
+        layer_type=layer_type, 
+        encoding="raw", 
+        resolution=[1,1,1]
+    )
+    
+    return vol
+
+def delete_layer(path=layer_path):
+    if os.path.exists(path):
+        shutil.rmtree(path)  
+
+# Helper Functions
+
+def create_volume_from_image(image, offset, layer_path, layer_type, resolution, encoding):
+  assert layer_type in ('image', 'segmentation', 'affinities')
+
+  offset = Vec(*offset)
+  volsize = Vec(*image.shape[:3])
+
+  data_type = str(image.dtype)
+  bounds = Bbox(offset, offset + volsize)
+
+  neuroglancer_chunk_size = find_closest_divisor(image.shape[:3], closest_to=[64,64,64])
+
+  info = CloudVolume.create_new_info(
+    num_channels=1, # Increase this number when we add more tests for RGB
+    layer_type=layer_type, 
+    data_type=data_type, 
+    encoding=encoding,
+    resolution=resolution, 
+    voxel_offset=bounds.minpt, 
+    volume_size=bounds.size3(),
+    mesh=(layer_type == 'segmentation'), 
+    chunk_size=neuroglancer_chunk_size,
+  )
+
+  vol = CloudVolume(layer_path, mip=0, info=info)
+  vol.commit_info()
+  vol[:,:,:] = image
+  return vol

--- a/ingestclient/test/test_backend.py
+++ b/ingestclient/test/test_backend.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 from ingestclient.core.backend import BossBackend, Backend
 from ingestclient.test.aws import Setup
 
+import boto3
 import os
 import unittest
 import json
@@ -32,7 +33,7 @@ class ResponsesMixin(object):
 
     def tearDown(self):
         super(ResponsesMixin, self).tearDown()
-        responses._default_mock.__exit__()
+        responses._default_mock.__exit__(None, None, None)
 
     def add_default_response(self):
         mocked_repsonse = {"id": 23}
@@ -122,6 +123,11 @@ class BossBackendTestMixin(object):
         b = BossBackend(self.example_config_data)
         b.setup(self.api_token)
 
+        # Make sure queue is empty.
+        sqs = boto3.resource('sqs')
+        queue = sqs.Queue(self.queue_url)
+        queue.purge()
+
         # Put some stuff on the task queue
         self.setup_helper.add_tasks(self.aws_creds["access_key"], self.aws_creds['secret_key'], self.queue_url, b)
 
@@ -137,6 +143,24 @@ class BossBackendTestMixin(object):
         assert isinstance(msg_id, str)
         assert isinstance(rx_handle, str)
         assert msg_body == self.setup_helper.test_msg[1]
+
+    def test_delete_task(self):
+        b = BossBackend(self.example_config_data)
+        b.setup(self.api_token)
+
+        # Make sure queue is empty.
+        sqs = boto3.resource('sqs')
+        queue = sqs.Queue(self.queue_url)
+        queue.purge()
+
+        # Put some stuff on the task queue
+        self.setup_helper.add_tasks(self.aws_creds["access_key"], self.aws_creds['secret_key'], self.queue_url, b)
+
+        # Join and get a task
+        b.join(23)
+        msg_id, rx_handle, msg_body = b.get_task()
+
+        assert b.delete_task(msg_id, rx_handle)
 
     def test_encode_tile_key(self):
         """Test encoding an object key"""

--- a/ingestclient/test/test_boss_validator_v02.py
+++ b/ingestclient/test/test_boss_validator_v02.py
@@ -1,0 +1,160 @@
+# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from ingestclient.core.validator import Validator, BossValidatorV02
+from ingestclient.core.backend import Backend, BossBackend
+from ingestclient.core.config import Configuration, ConfigFileError
+
+import os
+import unittest
+import json
+from pkg_resources import resource_filename
+
+class TestValidateConfig(unittest.TestCase):
+    def get_skeleton_config(self):
+        """
+        Returns a partial config that can be adjusted for different tests.
+
+        Returns:
+            (dict)
+        """
+        return {
+            "schema": {
+              "name": "boss-v0.2-schema",
+              "validator": "BossValidatorV02"
+            },
+            "client": {
+                "backend": {
+                  "name": "boss",
+                  "class": "BossBackend",
+                  "host": "api.theboss.io",
+                  "protocol": "https"
+                },
+                "path_processor": {
+                  "class": "ingestclient.plugins.cloudvolume.CloudVolumePathProcessor",
+                  "params": {
+                  }
+                }
+                #"tile_processor": {}
+                #"chunk_processor": {}
+            },
+            "database": {
+                "collection": "my_col_1",
+                "experiment": "my_exp_1",
+                "channel": "my_ch_1"
+            },
+            "ingest_job": {
+                # "ingest_type": "tile|volumetric",
+                "resolution": 0,
+                "extent": {
+                  "x": [0, 8192],
+                  "y": [0, 8192],
+                  "z": [0, 500],
+                  "t": [0, 1]
+                }
+            }
+        }
+
+    def test_valid_config(self):
+        schema_file = os.path.join(resource_filename("ingestclient", "schema"), "boss-v0.2-schema.json")
+        with open(schema_file, 'r') as file_handle:
+            schema = json.load(file_handle)
+
+        config_file = os.path.join(resource_filename("ingestclient", "test/data"), "boss-v0.2-test.json")
+        with open(config_file, 'rt') as example_file:
+            config_data = json.load(example_file)
+
+        config = Configuration(config_data)
+        validator = config.get_validator()
+        validator.schema = schema
+
+        msgs = validator.validate()
+        self.assertEqual(0, len(msgs['error']))
+
+    def test_no_chunk_processor(self):
+        schema_file = os.path.join(resource_filename("ingestclient", "schema"), "boss-v0.2-schema.json")
+        with open(schema_file, 'r') as file_handle:
+            schema = json.load(file_handle)
+
+        config_data = self.get_skeleton_config()
+        config_data['ingest_job']['ingest_type'] = 'volumetric'
+        config_data['ingest_job']['chunk_size'] = {'x': 1024, 'y': 1024, 'z': 64 }
+
+        config = Configuration(config_data)
+        validator = config.get_validator()
+        validator.schema = schema
+
+        msgs = validator.validate()
+        self.assertEqual(1, len(msgs['error']))
+        self.assertRegex(msgs['error'][0], '.*chunk_processor.*')
+
+    def test_no_chunk_size(self):
+        schema_file = os.path.join(resource_filename("ingestclient", "schema"), "boss-v0.2-schema.json")
+        with open(schema_file, 'r') as file_handle:
+            schema = json.load(file_handle)
+
+        config_data = self.get_skeleton_config()
+        config_data['ingest_job']['ingest_type'] = 'volumetric'
+        config_data['client']['chunk_processor'] = {
+            "class": "ingestclient.plugins.cloudvolume.CloudVolumeChunkProcessor",
+            "params": { "cloudpath": "gs://neuroglancer/foo/bar" }
+        }
+
+        config = Configuration(config_data)
+        validator = config.get_validator()
+        validator.schema = schema
+
+        msgs = validator.validate()
+        self.assertEqual(1, len(msgs['error']))
+        self.assertRegex(msgs['error'][0], '.*chunk_size.*')
+
+    def test_no_tile_processor(self):
+        schema_file = os.path.join(resource_filename("ingestclient", "schema"), "boss-v0.2-schema.json")
+        with open(schema_file, 'r') as file_handle:
+            schema = json.load(file_handle)
+
+        config_data = self.get_skeleton_config()
+        config_data['ingest_job']['ingest_type'] = 'tile'
+        config_data['ingest_job']['tile_size'] = {'x': 2048, 'y': 1024, 'z': 32 , 't': 1}
+
+        config = Configuration(config_data)
+        validator = config.get_validator()
+        validator.schema = schema
+
+        msgs = validator.validate()
+        self.assertEqual(1, len(msgs['error']))
+        self.assertRegex(msgs['error'][0], '.*tile_processor.*')
+
+    def test_no_tile_size(self):
+        schema_file = os.path.join(resource_filename("ingestclient", "schema"), "boss-v0.2-schema.json")
+        with open(schema_file, 'r') as file_handle:
+            schema = json.load(file_handle)
+
+        config_data = self.get_skeleton_config()
+        config_data['ingest_job']['ingest_type'] = 'tile'
+        config_data['client']['tile_processor'] = {
+            "class": "ingestclient.plugins.stack.ZindexStackTileProcessor",
+            "params": {}
+        }
+
+        config = Configuration(config_data)
+        validator = config.get_validator()
+        validator.schema = schema
+
+        msgs = validator.validate()
+        self.assertEqual(1, len(msgs['error']))
+        self.assertRegex(msgs['error'][0], '.*tile_size.*')
+
+

--- a/ingestclient/test/test_debug.py
+++ b/ingestclient/test/test_debug.py
@@ -32,7 +32,7 @@ class ResponsesMixin(object):
 
     def tearDown(self):
         super(ResponsesMixin, self).tearDown()
-        responses._default_mock.__exit__()
+        responses._default_mock.__exit__(None, None, None)
 
     def add_default_response(self):
         mocked_repsonse = {"id": 23}

--- a/ingestclient/test/test_engine.py
+++ b/ingestclient/test/test_engine.py
@@ -36,7 +36,7 @@ class ResponsesMixin(object):
 
     def tearDown(self):
         super(ResponsesMixin, self).tearDown()
-        responses._default_mock.__exit__()
+        responses._default_mock.__exit__(None, None, None)
 
     def add_default_response(self):
         mocked_repsonse = {"id": 23}

--- a/ingestclient/test/test_engine_volumetric.py
+++ b/ingestclient/test/test_engine_volumetric.py
@@ -58,6 +58,7 @@ class ResponsesMixin(object):
                                           },
                            "ingest_lambda": "my_lambda",
                            "tile_bucket_name": self.tile_bucket_name,
+                           "ingest_bucket_name": self.ingest_bucket_name,
                            "KVIO_SETTINGS": {"settings": "go here"},
                            "STATEIO_CONFIG": {"settings": "go here"},
                            "OBJECTIO_CONFIG": {"settings": "go here"},
@@ -138,11 +139,11 @@ class EngineBossTestMixin(object):
 
         # Check for tile to exist
         s3 = boto3.resource('s3')
-        tile_bucket = s3.Bucket(self.tile_bucket_name)
+        ingest_bucket = s3.Bucket(self.ingest_bucket_name)
 
         with tempfile.NamedTemporaryFile() as test_file:
             with open(test_file.name, 'wb') as raw_data:
-                tile_bucket.download_fileobj(VOLUMETRIC_CUBOID_KEY, raw_data)
+                ingest_bucket.download_fileobj(VOLUMETRIC_CUBOID_KEY, raw_data)
             with open(test_file.name, 'rb') as raw_data:
                 # Using an empty CloudVolume dataset so all values should be 0.
                 # dtype set in boss-v0.2-test.json under chunk_processor.params.info.data_type
@@ -187,11 +188,11 @@ class EngineBossTestMixin(object):
         assert True == engine.upload_cuboid(chunk, 1024, 2048, 32, VOLUMETRIC_CUBOID_KEY, VOLUMETRIC_CHUNK_KEY, XYZT_ORDER)
 
         s3 = boto3.resource('s3')
-        tile_bucket = s3.Bucket(self.tile_bucket_name)
+        ingest_bucket = s3.Bucket(self.ingest_bucket_name)
 
         with tempfile.NamedTemporaryFile() as test_file:
             with open(test_file.name, 'wb') as raw_data:
-                tile_bucket.download_fileobj(VOLUMETRIC_CUBOID_KEY, raw_data)
+                ingest_bucket.download_fileobj(VOLUMETRIC_CUBOID_KEY, raw_data)
             with open(test_file.name, 'rb') as raw_data:
                 # Using an empty CloudVolume dataset so all values should be 0.
                 # dtype set in boss-v0.2-test.json under chunk_processor.params.info.data_type
@@ -212,11 +213,11 @@ class EngineBossTestMixin(object):
         assert True == engine.upload_cuboid(chunk, 1024, 2048, 32, VOLUMETRIC_CUBOID_KEY, VOLUMETRIC_CHUNK_KEY, TZYX_ORDER)
 
         s3 = boto3.resource('s3')
-        tile_bucket = s3.Bucket(self.tile_bucket_name)
+        ingest_bucket = s3.Bucket(self.ingest_bucket_name)
 
         with tempfile.NamedTemporaryFile() as test_file:
             with open(test_file.name, 'wb') as raw_data:
-                tile_bucket.download_fileobj(VOLUMETRIC_CUBOID_KEY, raw_data)
+                ingest_bucket.download_fileobj(VOLUMETRIC_CUBOID_KEY, raw_data)
             with open(test_file.name, 'rb') as raw_data:
                 # Using an empty CloudVolume dataset so all values should be 0.
                 # dtype set in boss-v0.2-test.json under chunk_processor.params.info.data_type
@@ -237,11 +238,11 @@ class EngineBossTestMixin(object):
         assert True == engine.upload_cuboid(chunk, 1024, 512, 48, VOLUMETRIC_CUBOID_KEY, VOLUMETRIC_CHUNK_KEY, XYZ_ORDER)
 
         s3 = boto3.resource('s3')
-        tile_bucket = s3.Bucket(self.tile_bucket_name)
+        ingest_bucket = s3.Bucket(self.ingest_bucket_name)
 
         with tempfile.NamedTemporaryFile() as test_file:
             with open(test_file.name, 'wb') as raw_data:
-                tile_bucket.download_fileobj(VOLUMETRIC_CUBOID_KEY, raw_data)
+                ingest_bucket.download_fileobj(VOLUMETRIC_CUBOID_KEY, raw_data)
             with open(test_file.name, 'rb') as raw_data:
                 # Using an empty CloudVolume dataset so all values should be 0.
                 # dtype set in boss-v0.2-test.json under chunk_processor.params.info.data_type
@@ -262,11 +263,11 @@ class EngineBossTestMixin(object):
         assert True == engine.upload_cuboid(chunk, 1024, 512, 48, VOLUMETRIC_CUBOID_KEY, VOLUMETRIC_CHUNK_KEY, ZYX_ORDER)
 
         s3 = boto3.resource('s3')
-        tile_bucket = s3.Bucket(self.tile_bucket_name)
+        ingest_bucket = s3.Bucket(self.ingest_bucket_name)
 
         with tempfile.NamedTemporaryFile() as test_file:
             with open(test_file.name, 'wb') as raw_data:
-                tile_bucket.download_fileobj(VOLUMETRIC_CUBOID_KEY, raw_data)
+                ingest_bucket.download_fileobj(VOLUMETRIC_CUBOID_KEY, raw_data)
             with open(test_file.name, 'rb') as raw_data:
                 # Using an empty CloudVolume dataset so all values should be 0.
                 # dtype set in boss-v0.2-test.json under chunk_processor.params.info.data_type
@@ -299,8 +300,9 @@ class TestBossEngine(EngineBossTestMixin, ResponsesMixin, unittest.TestCase):
 
         cls.queue_url = cls.setup_helper.create_queue("test-queue")
 
-        cls.tile_bucket_name = "test-cuboid-store"
-        cls.setup_helper.create_bucket(cls.tile_bucket_name )
+        cls.tile_bucket_name = "test-tile-store"
+        cls.ingest_bucket_name = "test-cuboid-store"
+        cls.setup_helper.create_bucket(cls.ingest_bucket_name )
 
         # mock api token
         cls.api_token = "aalasdklbajklsbfasdklbfkjdsb"

--- a/ingestclient/test/test_engine_volumetric.py
+++ b/ingestclient/test/test_engine_volumetric.py
@@ -18,7 +18,7 @@ from ingestclient.core.validator import Validator, BossValidatorV02
 from ingestclient.core.backend import Backend, BossBackend
 from ingestclient.core.config import Configuration, ConfigFileError
 from ingestclient.core.consts import BOSS_CUBOID_X, BOSS_CUBOID_Y, BOSS_CUBOID_Z 
-from ingestclient.test.aws import Setup, VOLUMETRIC_CUBOID_KEY 
+from ingestclient.test.aws import Setup, VOLUMETRIC_CUBOID_KEY, VOLUMETRIC_CHUNK_KEY 
 from ingestclient.plugins.chunk import XYZ_ORDER, ZYX_ORDER, XYZT_ORDER, TZYX_ORDER
 
 import os
@@ -165,7 +165,7 @@ class EngineBossTestMixin(object):
         x = 1024
         y = 512
         z = 16
-        assert True == engine.upload_cuboid(chunk, x, y, z, VOLUMETRIC_CUBOID_KEY, XYZ_ORDER)
+        assert True == engine.upload_cuboid(chunk, x, y, z, VOLUMETRIC_CUBOID_KEY, VOLUMETRIC_CHUNK_KEY, XYZ_ORDER)
 
         exp_x = slice(x, x+BOSS_CUBOID_X, None)
         exp_y = slice(y, y+BOSS_CUBOID_Y, None)
@@ -184,7 +184,7 @@ class EngineBossTestMixin(object):
 
         engine.join()
 
-        assert True == engine.upload_cuboid(chunk, 1024, 2048, 32, VOLUMETRIC_CUBOID_KEY, XYZT_ORDER)
+        assert True == engine.upload_cuboid(chunk, 1024, 2048, 32, VOLUMETRIC_CUBOID_KEY, VOLUMETRIC_CHUNK_KEY, XYZT_ORDER)
 
         s3 = boto3.resource('s3')
         tile_bucket = s3.Bucket(self.tile_bucket_name)
@@ -209,7 +209,7 @@ class EngineBossTestMixin(object):
 
         engine.join()
 
-        assert True == engine.upload_cuboid(chunk, 1024, 2048, 32, VOLUMETRIC_CUBOID_KEY, TZYX_ORDER)
+        assert True == engine.upload_cuboid(chunk, 1024, 2048, 32, VOLUMETRIC_CUBOID_KEY, VOLUMETRIC_CHUNK_KEY, TZYX_ORDER)
 
         s3 = boto3.resource('s3')
         tile_bucket = s3.Bucket(self.tile_bucket_name)
@@ -234,7 +234,7 @@ class EngineBossTestMixin(object):
 
         engine.join()
 
-        assert True == engine.upload_cuboid(chunk, 1024, 512, 48, VOLUMETRIC_CUBOID_KEY, XYZ_ORDER)
+        assert True == engine.upload_cuboid(chunk, 1024, 512, 48, VOLUMETRIC_CUBOID_KEY, VOLUMETRIC_CHUNK_KEY, XYZ_ORDER)
 
         s3 = boto3.resource('s3')
         tile_bucket = s3.Bucket(self.tile_bucket_name)
@@ -259,7 +259,7 @@ class EngineBossTestMixin(object):
 
         engine.join()
 
-        assert True == engine.upload_cuboid(chunk, 1024, 512, 48, VOLUMETRIC_CUBOID_KEY, ZYX_ORDER)
+        assert True == engine.upload_cuboid(chunk, 1024, 512, 48, VOLUMETRIC_CUBOID_KEY, VOLUMETRIC_CHUNK_KEY, ZYX_ORDER)
 
         s3 = boto3.resource('s3')
         tile_bucket = s3.Bucket(self.tile_bucket_name)

--- a/ingestclient/test/test_engine_volumetric.py
+++ b/ingestclient/test/test_engine_volumetric.py
@@ -1,0 +1,315 @@
+# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+from ingestclient.core.engine import Engine
+from ingestclient.core.validator import Validator, BossValidatorV02
+from ingestclient.core.backend import Backend, BossBackend
+from ingestclient.core.config import Configuration, ConfigFileError
+from ingestclient.core.consts import BOSS_CUBOID_X, BOSS_CUBOID_Y, BOSS_CUBOID_Z 
+from ingestclient.test.aws import Setup, VOLUMETRIC_CUBOID_KEY 
+from ingestclient.plugins.chunk import XYZ_ORDER, ZYX_ORDER, XYZT_ORDER, TZYX_ORDER
+
+import os
+import unittest
+from unittest.mock import MagicMock
+import json
+import responses
+from pkg_resources import resource_filename
+import tempfile
+import boto3
+import blosc
+import numpy as np
+
+
+
+class ResponsesMixin(object):
+    """Mixin to setup requests mocking for the test class"""
+    def setUp(self):
+        responses._default_mock.__enter__()
+        self.add_default_response()
+        super(ResponsesMixin, self).setUp()
+
+    def tearDown(self):
+        super(ResponsesMixin, self).tearDown()
+        responses._default_mock.__exit__(None, None, None)
+
+    def add_default_response(self):
+        mocked_response = {"id": 23}
+        responses.add(responses.POST, 'https://api.theboss.io/latest/ingest/',
+                      json=mocked_response, status=201)
+
+        mocked_response = {"ingest_job": {"id": 23,
+                                          "ingest_queue": "https://aws.com/myqueue1",
+                                          "upload_queue": self.queue_url,
+                                          "status": 1,
+                                          "tile_count": 500,
+                                          },
+                           "ingest_lambda": "my_lambda",
+                           "tile_bucket_name": self.tile_bucket_name,
+                           "KVIO_SETTINGS": {"settings": "go here"},
+                           "STATEIO_CONFIG": {"settings": "go here"},
+                           "OBJECTIO_CONFIG": {"settings": "go here"},
+                           "credentials": self.aws_creds,
+                           "resource": {"resource": "stuff"}
+                           }
+        responses.add(responses.GET, 'https://api.theboss.io/latest/ingest/23',
+                      json=mocked_response, status=200)
+
+        responses.add(responses.DELETE, 'https://api.theboss.io/latest/ingest/23', status=204)
+
+
+
+class EngineBossTestMixin(object):
+
+    def test_create_instance(self):
+        """Method to test creating an instance from the factory"""
+        engine = Engine(self.config_file, self.api_token)
+
+        assert isinstance(engine, Engine) is True
+        assert isinstance(engine.backend, Backend) is True
+        assert isinstance(engine.backend, BossBackend) is True
+        assert isinstance(engine.validator, Validator) is True
+        assert isinstance(engine.validator, BossValidatorV02) is True
+        assert isinstance(engine.config, Configuration) is True
+
+        # Schema loaded
+        assert isinstance(engine.config.schema, dict) is True
+        assert engine.config.schema["type"] == "object"
+
+    def test_missing_file(self):
+        """Test creating a Configuration object"""
+        with self.assertRaises(ConfigFileError):
+            engine = Engine("/asdfhdfgkjldhsfg.json", self.api_token)
+
+    def test_bad_file(self):
+        """Test creating a Configuration object"""
+        with tempfile.NamedTemporaryFile(suffix='.json') as test_file:
+            with open(test_file.name, 'wt') as test_file_handle:
+                test_file_handle.write("garbage garbage garbage\n")
+
+            with self.assertRaises(ConfigFileError):
+                engine = Engine(test_file.name, self.api_token)
+
+    def test_setup(self):
+        """Test setting up the engine - no error should occur"""
+        engine = Engine(self.config_file, self.api_token)
+        engine.setup()
+
+    def test_create_job(self):
+        """Test creating an ingest job - mock server response"""
+        engine = Engine(self.config_file, self.api_token)
+
+        engine.create_job()
+
+        assert engine.ingest_job_id == 23
+
+    def test_join(self):
+        """Test joining an existing ingest job - mock server response"""
+        engine = Engine(self.config_file, self.api_token, 23)
+
+        engine.join()
+
+        assert engine.upload_job_queue == self.queue_url
+        assert engine.job_status == 1
+
+    def test_run(self):
+        """Test getting a task from the upload queue"""
+        engine = Engine(self.config_file, self.api_token, 23)
+        engine.msg_wait_iterations = 0
+
+        # Put some stuff on the task queue
+        self.setup_helper.add_volumetric_tasks(
+            self.aws_creds["access_key"], self.aws_creds['secret_key'], self.queue_url, engine.backend)
+
+        engine.join()
+        engine.run()
+
+        # Check for tile to exist
+        s3 = boto3.resource('s3')
+        tile_bucket = s3.Bucket(self.tile_bucket_name)
+
+        with tempfile.NamedTemporaryFile() as test_file:
+            with open(test_file.name, 'wb') as raw_data:
+                tile_bucket.download_fileobj(VOLUMETRIC_CUBOID_KEY, raw_data)
+            with open(test_file.name, 'rb') as raw_data:
+                # Using an empty CloudVolume dataset so all values should be 0.
+                # dtype set in boss-v0.2-test.json under chunk_processor.params.info.data_type
+                cuboid = self.s3_object_to_cuboid(raw_data.read(), 'uint8')
+                unique_vals = np.unique(cuboid)
+                assert 1 == len(unique_vals)
+                assert 0 == unique_vals[0]
+
+    def test_upload_cuboid_indexing(self):
+        data = np.random.randint(0, 256, (BOSS_CUBOID_X, BOSS_CUBOID_Y, BOSS_CUBOID_Z), 'uint8')
+        chunk = MagicMock(spec=np.ndarray)
+        chunk.__getitem__.return_value = data
+
+        engine = Engine(self.config_file, self.api_token, 23)
+        self.setup_helper.add_volumetric_tasks(
+            self.aws_creds["access_key"], self.aws_creds['secret_key'], self.queue_url, engine.backend)
+
+        engine.join()
+
+        x = 1024
+        y = 512
+        z = 16
+        assert True == engine.upload_cuboid(chunk, x, y, z, VOLUMETRIC_CUBOID_KEY, XYZ_ORDER)
+
+        exp_x = slice(x, x+BOSS_CUBOID_X, None)
+        exp_y = slice(y, y+BOSS_CUBOID_Y, None)
+        exp_z = slice(z, z+BOSS_CUBOID_Z, None)
+
+        chunk.__getitem__.assert_called_with((exp_x, exp_y, exp_z))
+
+    def test_upload_cuboid_random_data_xyzt_order(self):
+        data = np.random.randint(0, 256, (BOSS_CUBOID_X, BOSS_CUBOID_Y, BOSS_CUBOID_Z, 1), 'uint8')
+        chunk = MagicMock(spec=np.ndarray)
+        chunk.__getitem__.return_value = data
+
+        engine = Engine(self.config_file, self.api_token, 23)
+        self.setup_helper.add_volumetric_tasks(
+            self.aws_creds["access_key"], self.aws_creds['secret_key'], self.queue_url, engine.backend)
+
+        engine.join()
+
+        assert True == engine.upload_cuboid(chunk, 1024, 2048, 32, VOLUMETRIC_CUBOID_KEY, XYZT_ORDER)
+
+        s3 = boto3.resource('s3')
+        tile_bucket = s3.Bucket(self.tile_bucket_name)
+
+        with tempfile.NamedTemporaryFile() as test_file:
+            with open(test_file.name, 'wb') as raw_data:
+                tile_bucket.download_fileobj(VOLUMETRIC_CUBOID_KEY, raw_data)
+            with open(test_file.name, 'rb') as raw_data:
+                # Using an empty CloudVolume dataset so all values should be 0.
+                # dtype set in boss-v0.2-test.json under chunk_processor.params.info.data_type
+                cuboid = self.s3_object_to_cuboid(raw_data.read(), 'uint8')
+                assert np.array_equal(np.transpose(data), cuboid)
+
+    def test_upload_cuboid_random_data_tzyx_order(self):
+        data = np.random.randint(0, 256, (1, BOSS_CUBOID_Z, BOSS_CUBOID_Y, BOSS_CUBOID_X), 'uint8')
+        chunk = MagicMock(spec=np.ndarray)
+        chunk.__getitem__.return_value = data
+
+        engine = Engine(self.config_file, self.api_token, 23)
+        self.setup_helper.add_volumetric_tasks(
+            self.aws_creds["access_key"], self.aws_creds['secret_key'], self.queue_url, engine.backend)
+
+        engine.join()
+
+        assert True == engine.upload_cuboid(chunk, 1024, 2048, 32, VOLUMETRIC_CUBOID_KEY, TZYX_ORDER)
+
+        s3 = boto3.resource('s3')
+        tile_bucket = s3.Bucket(self.tile_bucket_name)
+
+        with tempfile.NamedTemporaryFile() as test_file:
+            with open(test_file.name, 'wb') as raw_data:
+                tile_bucket.download_fileobj(VOLUMETRIC_CUBOID_KEY, raw_data)
+            with open(test_file.name, 'rb') as raw_data:
+                # Using an empty CloudVolume dataset so all values should be 0.
+                # dtype set in boss-v0.2-test.json under chunk_processor.params.info.data_type
+                cuboid = self.s3_object_to_cuboid(raw_data.read(), 'uint8')
+                assert np.array_equal(data, cuboid)
+
+    def test_upload_cuboid_random_data_xyz_order(self):
+        data = np.random.randint(0, 256, (BOSS_CUBOID_X, BOSS_CUBOID_Y, BOSS_CUBOID_Z), 'uint8')
+        chunk = MagicMock(spec=np.ndarray)
+        chunk.__getitem__.return_value = data
+
+        engine = Engine(self.config_file, self.api_token, 23)
+        self.setup_helper.add_volumetric_tasks(
+            self.aws_creds["access_key"], self.aws_creds['secret_key'], self.queue_url, engine.backend)
+
+        engine.join()
+
+        assert True == engine.upload_cuboid(chunk, 1024, 512, 48, VOLUMETRIC_CUBOID_KEY, XYZ_ORDER)
+
+        s3 = boto3.resource('s3')
+        tile_bucket = s3.Bucket(self.tile_bucket_name)
+
+        with tempfile.NamedTemporaryFile() as test_file:
+            with open(test_file.name, 'wb') as raw_data:
+                tile_bucket.download_fileobj(VOLUMETRIC_CUBOID_KEY, raw_data)
+            with open(test_file.name, 'rb') as raw_data:
+                # Using an empty CloudVolume dataset so all values should be 0.
+                # dtype set in boss-v0.2-test.json under chunk_processor.params.info.data_type
+                cuboid = self.s3_object_to_cuboid(raw_data.read(), 'uint8')
+                assert np.array_equal(np.expand_dims(np.transpose(data), 0), cuboid)
+
+    def test_upload_cuboid_random_data_zyx_order(self):
+        data = np.random.randint(0, 256, (BOSS_CUBOID_Z, BOSS_CUBOID_Y, BOSS_CUBOID_X), 'uint8')
+        chunk = MagicMock(spec=np.ndarray)
+        chunk.__getitem__.return_value = data
+
+        engine = Engine(self.config_file, self.api_token, 23)
+        self.setup_helper.add_volumetric_tasks(
+            self.aws_creds["access_key"], self.aws_creds['secret_key'], self.queue_url, engine.backend)
+
+        engine.join()
+
+        assert True == engine.upload_cuboid(chunk, 1024, 512, 48, VOLUMETRIC_CUBOID_KEY, ZYX_ORDER)
+
+        s3 = boto3.resource('s3')
+        tile_bucket = s3.Bucket(self.tile_bucket_name)
+
+        with tempfile.NamedTemporaryFile() as test_file:
+            with open(test_file.name, 'wb') as raw_data:
+                tile_bucket.download_fileobj(VOLUMETRIC_CUBOID_KEY, raw_data)
+            with open(test_file.name, 'rb') as raw_data:
+                # Using an empty CloudVolume dataset so all values should be 0.
+                # dtype set in boss-v0.2-test.json under chunk_processor.params.info.data_type
+                cuboid = self.s3_object_to_cuboid(raw_data.read(), 'uint8')
+                assert np.array_equal(np.expand_dims(data, 0), cuboid)
+
+    def s3_object_to_cuboid(self, raw_data, data_type):
+        data = blosc.decompress(raw_data)
+        data_mat = np.frombuffer(data, dtype=data_type)
+        return np.reshape(data_mat, (1, BOSS_CUBOID_Z, BOSS_CUBOID_Y, BOSS_CUBOID_X), order='C')
+
+
+class TestBossEngine(EngineBossTestMixin, ResponsesMixin, unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        schema_file = os.path.join(resource_filename("ingestclient", "schema"), "boss-v0.2-schema.json")
+        with open(schema_file, 'r') as file_handle:
+            s = json.load(file_handle)
+            cls.mock_schema = {"schema": s}
+
+        cls.config_file = os.path.join(resource_filename("ingestclient", "test/data"), "boss-v0.2-test.json")
+        with open(cls.config_file, 'rt') as example_file:
+            cls.example_config_data = json.load(example_file)
+
+        # Setup AWS stuff
+        cls.setup_helper = Setup()
+        cls.setup_helper.mock = True
+        cls.setup_helper.start_mocking()
+
+        cls.queue_url = cls.setup_helper.create_queue("test-queue")
+
+        cls.tile_bucket_name = "test-cuboid-store"
+        cls.setup_helper.create_bucket(cls.tile_bucket_name )
+
+        # mock api token
+        cls.api_token = "aalasdklbajklsbfasdklbfkjdsb"
+
+        # mock aws creds
+        cls.aws_creds = {"access_key": "asdfasdf", "secret_key": "asdfasdfasdfadsf"}
+
+    @classmethod
+    def tearDownClass(cls):
+        # Stop mocking
+        cls.setup_helper.stop_mocking()
+

--- a/ingestclient/test/test_plugin_cloudvolume.py
+++ b/ingestclient/test/test_plugin_cloudvolume.py
@@ -1,0 +1,71 @@
+# Copyright 2016 The Johns Hopkins University Applied Physics Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import
+
+from .layer_harness import create_layer, delete_layer, layer_path
+from ingestclient.core.config import Configuration
+import json
+import numpy as np
+import os
+from pkg_resources import resource_filename
+import unittest
+
+class TestCloudVolume(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        cls.vol_name = 'test_vol'
+        create_layer((1036, 1026, 78), (0, 0, 0), layer_name=cls.vol_name, dtype=np.uint8)
+        cls.config_file = os.path.join(
+            resource_filename("ingestclient", "test/data"), "boss-v0.2-cloudvolume.json")
+
+        with open(cls.config_file, 'rt') as example_file:
+            cls.example_config_data = json.load(example_file)
+
+        cls.config = Configuration(cls.example_config_data)
+        cls.config.load_plugins()
+
+        # Point config at generated CloudVolume.
+        cls.config.config_data["client"]["chunk_processor"]["params"]["cloudpath"] = (
+            'file://{}{}'.format(layer_path, cls.vol_name))
+
+        cls.chunk_procesor = cls.config.chunk_processor_class
+        cls.chunk_procesor.setup(cls.config.get_chunk_processor_params())
+        cls.chunk_size = (
+            cls.config.config_data["ingest_job"]["chunk_size"]["x"],
+            cls.config.config_data["ingest_job"]["chunk_size"]["y"],
+            cls.config.config_data["ingest_job"]["chunk_size"]["z"],
+            1)  # Time dimension.
+
+    @classmethod
+    def teardDownClass(cls):
+        # Remove test CloudVolume.
+        delete_layer()
+
+    def test_process(self):
+        foo = None
+        chunk, order = self.chunk_procesor.process(foo, 0, 0, 0)
+        self.assertEqual(self.chunk_size, chunk.shape)
+
+
+    def test_process_chunk_trimmed(self):
+        """
+        Ensure that a smaller chunk returned when the CloudVolume's extents
+        exceeded.
+        """
+        foo = None
+        chunk, order = self.chunk_procesor.process(foo, 1024, 1024, 64)
+        expected = (12, 2, 14, 1)
+        self.assertEqual(expected, chunk.shape)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 jsonschema>=2.5.1
 six>=1.10.0
 requests>=2.11.1
-responses==0.5.1
+responses>=0.9.0
 boto3>=1.4.0
-moto==0.4.25
+moto==1.3.3
 Pillow>=3.3.1
 numpy>=1.11.1
 nose2>=0.6.5


### PR DESCRIPTION
Add support for volumetric (3D) ingest. This first iteration supports Princeton's CloudVolume.

A new schema is provided: boss-v0.2-schema

It contains a new processor for chunks which are 3D pieces of the dataset. The chunk's dimensions must be a multiple of the Boss cuboid size: 512, 512, 16
