### PR TITLE
Conrad dev2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
         - run:
             name: Installing pip requirements at plugins level
             command: |
-                cd cd ingestclient/plugins/requirements/
+                cd ingestclient/plugins/requirements/
                 sudo pip install -r cloudvolume_requirements.txt
 
         - save_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,37 +9,36 @@ jobs:
       - image: circleci/python:3.6.5
 
     steps:
-        - checkout
+      - checkout
         
-        - run: mkdir test-reports
+      - run: mkdir test-reports
         
         - restore_cache:  # ensure this step occurs *before* installing dependencies
-
             keys:
-                - cache-{{ checksum "requirements.txt" }}
-                - cache-
+              - cache-{{ checksum "requirements.txt" }}
+              - cache-
                 
         - run:
             name: Installing pip requirements at top level
             command: |
-                sudo pip install -r requirements.txt
+              sudo pip install -r requirements.txt
                 
         - run:
             name: Installing pip requirements at plugins level
             command: |
-                cd ingestclient/plugins/requirements/
-                sudo pip install -r cloudvolume_requirements.txt
+              cd ingestclient/plugins/requirements/
+              sudo pip install -r cloudvolume_requirements.txt
 
         -run:
             name: Setup Dummy AWS creds
             command: |
-                mkdir ~/.aws
-                echo -e "[default]\naws_access_key_id = foo\naws_secret_access_key = bar" > ~/.aws/credentials
+              mkdir ~/.aws
+              echo -e "[default]\naws_access_key_id = foo\naws_secret_access_key = bar" > ~/.aws/credentials
                   
         - save_cache:
             paths:
-                - ~/.local
-                - ~/.cache
+              - ~/.local
+              - ~/.cache
             key: cache-{{ checksum "requirements.txt" }}
 
         ####  Run Tests
@@ -47,12 +46,12 @@ jobs:
         - run:
             name: Running tests ... python unit tests [pipe stdout/err to results.txt]
             command: |
-                python -m unittest -v  &> /tmp/unittest_results.txt
+              python -m unittest -v  &> /tmp/unittest_results.txt
 
         - run:
             name: Running tests ... nose2 (on fail)
             command: |
-                nose2
+              nose2
             when: on_fail
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,6 +31,12 @@ jobs:
                 cd ingestclient/plugins/requirements/
                 sudo pip install -r cloudvolume_requirements.txt
 
+        -run:
+            name: Setup Dummy AWS creds
+            command: |
+                  mkdir ~/.aws
+                  echo -e "[default]\naws_access_key_id = foo\naws_secret_access_key = bar" > ~/.aws/credentials
+                  
         - save_cache:
             paths:
                 - ~/.local

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,10 +50,8 @@ jobs:
               python -m unittest -v  &> /tmp/unittest_results.txt
 
         - run:
-            name: Running tests ... nose2 (on fail)
-            command: |
-              nose2
-            when: on_fail
+            name: Running tests ... nose2 (another perspective)
+            command: nose2
 
 
         - store_artifacts:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,9 @@ jobs:
       - image: circleci/python:3.6.5
 
     steps:
-      - checkout
+        - checkout
         
-      - run: mkdir test-reports
+        - run: mkdir test-reports
         
         - restore_cache:  # ensure this step occurs *before* installing dependencies
             keys:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,13 +28,7 @@ jobs:
             command: |
               cd ingestclient/plugins/requirements/
               sudo pip install -r cloudvolume_requirements.txt
-
-        - run:
-            name: Setup Dummy AWS creds
-            command: |
-              mkdir ~/.aws
-              echo -e "[default]\naws_access_key_id = foo\naws_secret_access_key = bar" > ~/.aws/credentials
-                  
+                
         - save_cache:
             paths:
               - ~/.local
@@ -42,6 +36,13 @@ jobs:
             key: cache-{{ checksum "requirements.txt" }}
 
         ####  Run Tests
+
+        - run:
+            name: Setup Dummy AWS creds
+            command: |
+              mkdir ~/.aws
+              echo -e "[default]\naws_access_key_id = foo\naws_secret_access_key = bar" > ~/.aws/credentials
+              echo -e "[default]\nregion = us-east-1\noutput = json" > ~/.aws/config        
 
         - run:
             name: Running tests ... python unit tests [pipe stdout/err to results.txt]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,10 @@ jobs:
             name: Installing pip requirements
             command: |
                 sudo pip install -r requirements.txt
+                cd ingestclient/plugins/requirements 
+                sudo pip install -r cloudvolume_requirements.txt
 
-                
+
 
         - save_cache:
             paths:
@@ -33,15 +35,12 @@ jobs:
                 - ~/.cache
             key: cache-{{ checksum "requirements.txt" }}
 
-
         ####  Run Tests
 
         - run:
             name: Running tests ... python unit tests [pipe stdout/err to results.txt]
             command: |
                 python -m unittest -v  &> /tmp/unittest_results.txt
-
-
 
         - run:
             name: Running tests ... nose2 (on fail)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,14 +24,12 @@ jobs:
             name: Installing pip requirements at top level
             command: |
                 sudo pip install -r requirements.txt
-
-        -run:
-            name: Install pip requirements at plugins level
-            command: | 
-              cd ingestclient/plugins/requirements 
-              sudo pip install -r cloudvolume_requirements.txt
-
-
+                
+        - run:
+            name: Installing pip requirements at plugins level
+            command: |
+                cd cd ingestclient/plugins/requirements/
+                sudo pip install -r cloudvolume_requirements.txt
 
         - save_cache:
             paths:
@@ -56,7 +54,3 @@ jobs:
         - store_artifacts:
             path: /tmp
             destination: unittest_results.txt
-
-
-
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,5 @@
 # Python CircleCI 2.0 configuration file
 #
-
 version: 2
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,8 @@ jobs:
         -run:
             name: Setup Dummy AWS creds
             command: |
-                  mkdir ~/.aws
-                  echo -e "[default]\naws_access_key_id = foo\naws_secret_access_key = bar" > ~/.aws/credentials
+                mkdir ~/.aws
+                echo -e "[default]\naws_access_key_id = foo\naws_secret_access_key = bar" > ~/.aws/credentials
                   
         - save_cache:
             paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,59 @@
+# Python CircleCI 2.0 configuration file
+#
+
+version: 2
+
+jobs:
+  build:
+    working_directory: ~/ingest-client
+    docker:
+      - image: circleci/python:3.6.5
+
+    steps:
+        - checkout
+        
+        - run: mkdir test-reports
+        
+        - restore_cache:  # ensure this step occurs *before* installing dependencies
+
+            keys:
+                - cache-{{ checksum "requirements.txt" }}
+                - cache-
+                
+        - run:
+            name: Installing pip requirements
+            command: |
+                sudo pip install -r requirements.txt
+
+                
+
+        - save_cache:
+            paths:
+                - ~/.local
+                - ~/.cache
+            key: cache-{{ checksum "requirements.txt" }}
+
+
+        ####  Run Tests
+
+        - run:
+            name: Running tests ... python unit tests [pipe stdout/err to results.txt]
+            command: |
+                python -m unittest -v  &> /tmp/unittest_results.txt
+
+
+
+        - run:
+            name: Running tests ... nose2 (on fail)
+            command: |
+                nose2
+            when: on_fail
+
+
+        - store_artifacts:
+            path: /tmp
+            destination: unittest_results.txt
+
+
+
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,11 +21,15 @@ jobs:
                 - cache-
                 
         - run:
-            name: Installing pip requirements
+            name: Installing pip requirements at top level
             command: |
                 sudo pip install -r requirements.txt
-                cd ingestclient/plugins/requirements 
-                sudo pip install -r cloudvolume_requirements.txt
+
+        -run:
+            name: Install pip requirements at plugins level
+            command: | 
+              cd ingestclient/plugins/requirements 
+              sudo pip install -r cloudvolume_requirements.txt
 
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ jobs:
               cd ingestclient/plugins/requirements/
               sudo pip install -r cloudvolume_requirements.txt
 
-        -run:
+        - run:
             name: Setup Dummy AWS creds
             command: |
               mkdir ~/.aws

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ six>=1.10.0
 requests>=2.11.1
 responses>=0.9.0
 boto3>=1.4.0
-moto==1.3.3
+moto>=1.3.7
 Pillow>=3.3.1
 numpy>=1.11.1
 nose2>=0.6.5


### PR DESCRIPTION
Guys could I get a PR on this?  For one thing, it supports Circle 2 (circle 1 is no longer supported) so this can't hurt any!  Also this works for at least python3 container. So my thinking is - we may as well use this. I can continue to work on adding python2 container support for py2.7 tests.  And add that to the workflow shortly.  Thoughts? 