### PR TITLE
Add a dtype check to stack plugin

### DIFF
--- a/ingestclient/plugins/stack.py
+++ b/ingestclient/plugins/stack.py
@@ -148,10 +148,14 @@ class ZindexStackTileProcessor(TileProcessor):
         y_range = [self.parameters["ingest_job"]["tile_size"]["y"] * y_index,
                    self.parameters["ingest_job"]["tile_size"]["y"] * (y_index + 1)]
 
+        # Allowed data types:
+        allowed_types = [np.uint8, np.uint16, np.uint64]
+
         # Save sub-img to png and return handle
         tile_data = Image.open(file_handle)
         tile_arr = np.array(tile_data)
-        if tile_arr.dtype != np.uint8 and tile_arr.dtype != np.uint64:
+        if tile_arr.dtype not in allowed_types:
+            print("Your data type is not uint8, uint16 or uint64, converting to uint8 and attempting upload.")
             tile_arr = np.uint8(tile_arr/256)
             tile_data = Image.fromarray(tile_arr)
         upload_img = tile_data.crop((x_range[0], y_range[0], x_range[1], y_range[1]))

--- a/ingestclient/plugins/stack.py
+++ b/ingestclient/plugins/stack.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import
 import six
 from PIL import Image
+import numpy as np
 import re
 import os
 
@@ -149,6 +150,10 @@ class ZindexStackTileProcessor(TileProcessor):
 
         # Save sub-img to png and return handle
         tile_data = Image.open(file_handle)
+        tile_arr = np.array(tile_data)
+        if tile_arr.dtype != np.uint8 or tile_arr.dtype != np.uint64:
+            tile_arr = np.uint8(tile_arr/256)
+            tile_data = Image.fromarray(tile_arr)
         upload_img = tile_data.crop((x_range[0], y_range[0], x_range[1], y_range[1]))
         output = six.BytesIO()
         upload_img.save(output, format=canonical_extension(self.parameters["extension"]))

--- a/ingestclient/plugins/stack.py
+++ b/ingestclient/plugins/stack.py
@@ -151,7 +151,7 @@ class ZindexStackTileProcessor(TileProcessor):
         # Save sub-img to png and return handle
         tile_data = Image.open(file_handle)
         tile_arr = np.array(tile_data)
-        if tile_arr.dtype != np.uint8 or tile_arr.dtype != np.uint64:
+        if tile_arr.dtype != np.uint8 and tile_arr.dtype != np.uint64:
             tile_arr = np.uint8(tile_arr/256)
             tile_data = Image.fromarray(tile_arr)
         upload_img = tile_data.crop((x_range[0], y_range[0], x_range[1], y_range[1]))


### PR DESCRIPTION
I realize now I never put this PR out there. Not sure if we definetely want it but thought it would be good to let you guys take a look at it. It is a super short fix. 

This problem came up when I was trying to upload some data for Church's team that was not uint 8 or uint16. The ingest client would allow me to upload, but the data would never show up. This guarantees that the data is one of the two types. 

Let me know if I should just close the PR. 