### PR TITLE
Put new message on tile index queue before deleting from upload queue - to master

### DIFF
--- a/ingestclient/core/engine.py
+++ b/ingestclient/core/engine.py
@@ -446,15 +446,16 @@ class Engine(object):
                         os.getpid(), e))
                     return False
 
-        # Success, so remove message from upload queue.
-        if not self.backend.delete_task(message_id, receipt_handle):
-            return False
 
         # Put tile on the tile index queue.
         max_put_retries = 3
         if not self.backend.put_task(json.dumps(metadata, separators=(',', ':')), max_put_retries):
             return False
 
+        # Success, so remove message from upload queue.
+        if not self.backend.delete_task(message_id, receipt_handle):
+            return False
+        
         return True
 
     def upload_chunk(self, msg, message_id, receipt_handle):


### PR DESCRIPTION
Updated the steps in the engine.py.
It now puts new tile message on tile index queue before deleting message from upload queue.
Before if the tile index queue failed to load after we already deleted the message from the upload queue the data would become lost.