### PR TITLE
Updated s3 filesystem util to allow for wildcard & bug fixes to zstac…

### DIFF
--- a/ingestclient/plugins/stack.py
+++ b/ingestclient/plugins/stack.py
@@ -154,6 +154,9 @@ class ZindexStackTileProcessor(TileProcessor):
         tile_crop_index_upper = y_range[0] - self.parameters["ingest_job"]["extent"]["y"][0]
         tile_crop_index_lower = tile_crop_index_upper + self.parameters["ingest_job"]["tile_size"]["y"]
 
+        # Allowed data types:
+        allowed_types = [np.uint8, np.uint16, np.uint64]
+
         # Save sub-img to png and return handle
         try:
             tile_data = Image.open(file_handle)
@@ -163,7 +166,8 @@ class ZindexStackTileProcessor(TileProcessor):
                 tile_arr = np.uint8(tile_arr/256)
                 tile_data = Image.fromarray(tile_arr)
             upload_img = tile_data.crop((tile_crop_index_left, tile_crop_index_upper, tile_crop_index_right, tile_crop_index_lower))
-        except OSError:
+        except OSError as e:
+            print(e)
             print("Failed on {}..replacing with black".format(file_path))
             tile_data = np.zeros((self.parameters["ingest_job"]["tile_size"]["x"], self.parameters["ingest_job"]["tile_size"]["y"]))
             upload_img = Image.fromarray(tile_data, mode='RGB')


### PR DESCRIPTION
We can decide whether we want to pull these in or not. 

Changes still need some cleanup but thought I'd put here for discussion. 

The updates allow you to pass in a wildcard for a file name which is very useful when your file name has some dynamic portions that are not important to your x,y,z.

Also fixes a bug I found on the plugin related to the use of Image.crop()

If we don't pull this in, I will make another PR with just the Image.crop changes.  

NOTE: Right now if a file doesn't exist I just continue to run the loop and print out a statement to tell the user we skipped it. But it would be awesome to log the tile instead. I am currently running this on an ingest, and it is successfully only excluding the tiles known to be missing from the data set. 