### PR TITLE
Add ETA indicator

### DIFF
--- a/ingestclient/core/engine.py
+++ b/ingestclient/core/engine.py
@@ -280,11 +280,11 @@ class Engine(object):
                         remaining_min = status["current_message_count"] / avg_tile_rate
                         eta_text = "calculating ETA..."
                         if remaining_min > 60*24:
-                            eta_text = "ETA: {:.2f} days".format(remaining_min / (60/24))
+                            eta_text = "ETA: {:.2f} days".format(remaining_min / (60 * 24))
                         elif remaining_min > 60:
                             eta_text = "ETA: {:.2f} hours".format(remaining_min / 60)
                         else:
-                            eta_text = "ETA: {:.2f} minutes"
+                            eta_text = "ETA: {:.2f} minutes".format(remaining_min)
 
                         log_str += " - Approx {:d} of {:d} {} remaining, {}".format(
                             status["current_message_count"],


### PR DESCRIPTION
Fix of previous PR, #33, and fixes #31.

Includes in the status line an "ETA" prediction based upon the performance so far:

```
Uploading ~724.00 chunks/min - Approx 56223 of 714040 chunks remaining, ETA: 13.45 days - Elapsed time 18.77 minutes
```

Will print `minutes`, `hours`, or `days` if time is greater than 1 sec, 1 hour, or 1 day, respectively.