### PR TITLE
Increase exp backoff

### DIFF
--- a/ingestclient/core/backend.py
+++ b/ingestclient/core/backend.py
@@ -412,7 +412,7 @@ class BossBackend(Backend):
                 exp_backoff = 100 * 2 ** (retries + 4)  # in ms
                 pause_for = random.uniform(1, min(max_pause_in_ms, exp_backoff)) / 1000  # in secs
                 if r.status_code == 400:
-                    print(r.text)   # Can see rate is being exceeded and if any other 400s that are occuring.
+                    print(r.text)   # Can see if rate is being exceeded and if any other 400s are occuring.
                 print("Join request failed with code: {}, retry attempt: {}, pausing for {:0.3f} seconds before retrying.".format(r.status_code, retries, pause_for))
                 time.sleep(pause_for)
             elif r.status_code != 200:

--- a/ingestclient/core/backend.py
+++ b/ingestclient/core/backend.py
@@ -402,7 +402,6 @@ class BossBackend(Backend):
         maximum_retries = 1000
         retries = 0
         max_pause_in_ms = 1000000
-        exp_backoff = 0
         while True:
             r = requests.get('{}/{}/ingest/{}'.format(self.host, self.api_version, ingest_job_id),
                              headers=self.api_headers, verify=self.validate_ssl)
@@ -410,8 +409,7 @@ class BossBackend(Backend):
                 retries += 1
                 if retries > maximum_retries:
                     raise Exception("After {} attempts, failed to join ingest job: {}".format(maximum_retries, r.text))
-                if exp_backoff < max_pause_in_ms:
-                    exp_backoff = 100 * 2 ** (retries + 4)  # in ms
+                exp_backoff = 100 * 2 ** (retries + 4)  # in ms
                 pause_for = random.uniform(1, min(max_pause_in_ms, exp_backoff)) / 1000  # in secs
                 if r.status_code == 400:
                     print(r.text)   # Can see rate is being exceeded and if any other 400s that are occuring.

--- a/ingestclient/core/backend.py
+++ b/ingestclient/core/backend.py
@@ -411,10 +411,10 @@ class BossBackend(Backend):
 
                 exp_backoff = 100 * 2 ** retries  # in ms
                 pause_for = random.uniform(1, min(300000, exp_backoff)) / 1000
-                print("Join request failed with: code {}, pausing for {:0.3f} seconds before retrying.".format(r.status_code, pause_for))
+                print("Join request failed with code: {}, retry attempt: {}, pausing for {:0.3f} seconds before retrying.".format(r.status_code, retries, pause_for))
                 time.sleep(pause_for)
             elif r.status_code != 200:
-                raise Exception("Failed to join ingest job: {}".format(r.text))
+                raise Exception("Failed to join ingest job after {} retry attempts: {}".format(retries, r.text))
             else:
                 result = r.json()
                 job_status = int(result['ingest_job']["status"])

--- a/ingestclient/core/backend.py
+++ b/ingestclient/core/backend.py
@@ -399,7 +399,7 @@ class BossBackend(Backend):
         """
 
         wp = WaitPrinter()
-        maximum_retries = 100
+        maximum_retries = 1000
         retries = 0
         while True:
             r = requests.get('{}/{}/ingest/{}'.format(self.host, self.api_version, ingest_job_id),
@@ -410,8 +410,8 @@ class BossBackend(Backend):
                     raise Exception("After {} attempts, failed to join ingest job: {}".format(maximum_retries, r.text))
 
                 exp_backoff = 100 * 2 ** retries  # in ms
-                pause_for = random.uniform(1, min(30000, exp_backoff)) / 1000
-                print("Join request failed with: {} pausing for {:0.3f} seconds before retrying.".format(r.status_code, pause_for))
+                pause_for = random.uniform(1, min(300000, exp_backoff)) / 1000
+                print("Join request failed with: code {}, pausing for {:0.3f} seconds before retrying.".format(r.status_code, pause_for))
                 time.sleep(pause_for)
             elif r.status_code != 200:
                 raise Exception("Failed to join ingest job: {}".format(r.text))


### PR DESCRIPTION
Increased number of retry attempts to be 1000 from 100.  Exponential backoff sleeps for a random number of seconds between 1 to min(5min, exp backoff)
Also added more information about number of retries in status messages.

This should allow for larger sleep times between retries