### PR TITLE
Add a custom number of seconds in between processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.11.0
 
 * Added an optional `--ramp_seconds` / `-r` flag to delay the creation of parallel processes. A ramp value of 10 will wait ten seconds in between creating new processes. This is helpful when the source of the ingest data needs time to scale (e.g. Google Cloud Storage).
+* Add an intern chunk processor for ingesting large cutouts.
 
 ## 0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Boss Ingest Client Changelog
 
+## 0.11.0
+
+* Added an optional `--ramp_seconds` / `-r` flag to delay the creation of parallel processes. A ramp value of 10 will wait ten seconds in between creating new processes. This is helpful when the source of the ingest data needs time to scale (e.g. Google Cloud Storage).
+
 ## 0.10.0
 
 *Dropping* support for Python 2

--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ There are three primary operations you can perform with the ingest client: Creat
 		boss-ingest <absolute_path_to_config_file> -p <number_of_processes>
 		```
 
+	- If you are using multiple parallel client processes, you may choose to optionally pass a `--ramp_seconds`/`-r` flag with a number of seconds to delay in between creating processes. This is helpful when the source of ingest data needs time to scale (e.g. google cloud storage buckets, or a load-balanced web server).
+
 - **Logging**
 	-   You can choose where to write the log file by specifying and absolute file path suing the -l parameter. If omitted, data is logged in `~/.boss-ingest`
 

--- a/ingestclient/__init__.py
+++ b/ingestclient/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.10.0'
+__version__ = '0.11.0'
 
 
 def check_version():

--- a/ingestclient/client.py
+++ b/ingestclient/client.py
@@ -139,6 +139,9 @@ def get_parser():
     parser.add_argument("--processes_nb", "-p", type=int,
                         default=1,
                         help="The number of client processes that will upload the images of the ingest job.")
+    parser.add_argument("--ramp_seconds", "-r", type=int,
+                        default=1,
+                        help="The number of seconds to wait in between provisioning client processes.")
     parser.add_argument("config_file", nargs='?', help="Path to the ingest job configuration file")
 
     return parser
@@ -171,7 +174,7 @@ def start_workers(ingest_job_id, args, configuration):
         new_process.start()
 
         # Sleep to slowly ramp up load on lambda
-        time.sleep(.5)
+        time.sleep(args.ramp_seconds)
 
     return workers
 

--- a/ingestclient/client.py
+++ b/ingestclient/client.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright 2019 The Johns Hopkins University Applied Physics Laboratory
+# Copyright 2021 The Johns Hopkins University Applied Physics Laboratory
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
Passing `--ramp_seconds 30` will wait 30 seconds before creating each subsequent worker. This is useful for data sources such as Google Cloud Storage buckets where there is a penalty for making too many requests before it has had time to scale up.

fixes #37 