### PR TITLE
Prevent exception in backend.get_task().

### DIFF
--- a/ingestclient/core/backend.py
+++ b/ingestclient/core/backend.py
@@ -564,6 +564,7 @@ class BossBackend(Backend):
             (str, str, dict): message_id, receipt_handle, message contents
         """
         try_cnt = 0
+        msg = None
         while try_cnt < 19:
             try:
                 msg = self.upload_queue.receive_messages(MaxNumberOfMessages=1, WaitTimeSeconds=1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,8 @@ urllib3>=1.25.10
 boto3>=1.16.54
 
 # moto lower then 1.3.16 creates unit tests to fail
-moto>=1.3.16
+# 2.0.0 requires more changes, so staying at 1.x for now.
+moto>=1.3.16,<2.0.0
 Pillow>=3.3.1
 numpy>=1.11.1
 intern>=1.2.0


### PR DESCRIPTION
It was possible for `msg` to never be assigned if no messages are ever
received from SQS in `get_task()`.