### PR TITLE
Update canonical name for JPEGs

### DIFF
--- a/ingestclient/plugins/stack.py
+++ b/ingestclient/plugins/stack.py
@@ -178,7 +178,7 @@ class ZindexStackTileProcessor(TileProcessor):
 
 EXTENSIONS =  {
     'TIFF': ['TIF', 'TIFF'],
-    'JPG' : ['JPG', 'JPEG']
+    'JPEG' : ['JPG', 'JPEG']
 }
 
 def canonical_extension(extension):


### PR DESCRIPTION
Canonical name is `JPEG`, not `JPG`.

https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html#jpeg
