### PR TITLE
added long_description_content_type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
 
     description='Ingest client for the Boss',
     long_description=long_description,
+    long_description_content_type="text/markdown",
 
     install_requires=install_requires,
     dependency_links=dependency_links,


### PR DESCRIPTION
Be default long_description's content type defaults to reStructuredText

Added new line to make content type be markdown.