### PR TITLE
updated requirements to jump over a version of Pillow that caused pro…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,9 @@ boto3>=1.16.54
 # moto lower then 1.3.16 creates unit tests to fail
 # 2.0.0 requires more changes, so staying at 1.x for now.
 moto>=1.3.16,<2.0.0
-Pillow>=3.3.1
+# Pillow is pinned here because 8.3.0 had an error that caused tile_ingest_lambda to fail
+# https://pillow.readthedocs.io/en/stable/releasenotes/8.3.1.html#fixed-regression-converting-to-numpy-arrays 
+Pillow>=8.3.1
 numpy>=1.11.1
 intern>=1.2.0
 


### PR DESCRIPTION
…blems.

Updated because of this:
https://pillow.readthedocs.io/en/stable/releasenotes/8.3.1.html#fixed-regression-converting-to-numpy-arrays

See https://github.com/jhuapl-boss/spdb/pull/31